### PR TITLE
Prevent wasted recalculations of TopBar

### DIFF
--- a/client/src/main/scala/com.olegych.scastie.client/ApiReusability.scala
+++ b/client/src/main/scala/com.olegych.scastie.client/ApiReusability.scala
@@ -1,0 +1,11 @@
+package com.olegych.scastie.client
+
+import com.olegych.scastie.api._
+import japgolly.scalajs.react.extra.Reusability
+
+object ApiReusability {
+
+  implicit val reusabilityUser: Reusability[User] =
+    Reusability.byRef || Reusability.caseClass
+
+}

--- a/client/src/main/scala/com.olegych.scastie.client/AppBackend.scala
+++ b/client/src/main/scala/com.olegych.scastie.client/AppBackend.scala
@@ -4,11 +4,10 @@ package client
 import api._
 import japgolly.scalajs.react._
 import autowire._
-
+import japgolly.scalajs.react.extra.StateSnapshot
 import scalajs.concurrent.JSExecutionContext.Implicits.queue
 import org.scalajs.dom._
 import upickle.default.{read => uread}
-
 import scala.util.{Failure, Success}
 import scala.concurrent.Future
 
@@ -138,6 +137,8 @@ class AppBackend(scope: BackendScope[AppProps, AppState]) {
 
   def setView(newView: View): Callback =
     scope.modState(_.setView(newView))
+
+  val viewSnapshot = StateSnapshot.withReuse.prepare(setView)
 
   def setTarget(target: ScalaTarget): Callback =
     scope.modState(_.setTarget(target))

--- a/client/src/main/scala/com.olegych.scastie.client/Views.scala
+++ b/client/src/main/scala/com.olegych.scastie.client/Views.scala
@@ -1,6 +1,7 @@
 package com.olegych.scastie
 package client
 
+import japgolly.scalajs.react.extra.Reusability
 import org.scalajs.dom
 
 sealed trait View
@@ -8,6 +9,9 @@ object View {
   case object Editor extends View
   case object BuildSettings extends View
   case object CodeSnippets extends View
+
+  implicit val reusability: Reusability[View] =
+    Reusability.by_==
 
   import upickle.default._
 

--- a/client/src/main/scala/com.olegych.scastie.client/components/MainPanel.scala
+++ b/client/src/main/scala/com.olegych.scastie.client/components/MainPanel.scala
@@ -3,55 +3,50 @@ package client
 package components
 
 import japgolly.scalajs.react._
-import japgolly.scalajs.react.vdom.all.{`class` => clazz, _}
+import japgolly.scalajs.react.vdom.all._
 
 object MainPanel {
   private val component =
     ScalaComponent
       .builder[(AppState, AppBackend, AppProps)]("MainPanel")
       .render_P {
-        case (state, backend, props) => {
-          def show(view: View) = {
-            if (view == state.view) TagMod(display.block)
-            else TagMod(display.none)
-          }
+        case (state, backend, props) =>
+
+          def show(view: View) =
+            if (view == state.view) display.block
+            else display.none
 
           val embedded = props.embedded.isDefined
 
           val embeddedMenu =
-            if (embedded) TagMod(EmbeddedMenu(state, backend))
-            else EmptyVdom
+            EmbeddedMenu(state, backend).when(embedded)
 
           val consoleCssForEditor =
-            if (state.consoleState.consoleIsOpen)
-              TagMod(clazz := "console-open")
-            else EmptyVdom
+            (cls := "console-open").when(state.consoleState.consoleIsOpen)
 
           val snippets =
-            if (state.user.isDefined) {
-              div(clazz := "snippets-container",
-                  clazz := "inner-container",
-                  show(View.CodeSnippets))(
-                CodeSnippets(props.router, state, backend)
-              )
-            } else EmptyVdom
+            div(cls := "snippets-container",
+                cls := "inner-container",
+                show(View.CodeSnippets))(
+              CodeSnippets(props.router, state, backend)
+            ).when(state.user.isDefined)
 
-          div(clazz := "main-panel")(
-            // pre(clazz := "debug")(),
-            TopBar(state, backend),
+          div(cls := "main-panel",
+            // pre(cls := "debug")(),
+            TopBar(backend.viewSnapshot(state.view), state.user).render,
             EditorTopBar(state, backend, props.snippetId),
-            div(clazz := "content")(
-              div(clazz := "editor-container",
-                  clazz := "inner-container",
+            div(cls := "content",
+              div(cls := "editor-container",
+                  cls := "inner-container",
                   show(View.Editor))(
-                div(clazz := "code", consoleCssForEditor)(
+                div(cls := "code", consoleCssForEditor)(
                   Editor(state, backend),
                   embeddedMenu
                 ),
                 Console(state, backend)
               ),
-              div(clazz := "settings-container",
-                  clazz := "inner-container",
+              div(cls := "settings-container",
+                  cls := "inner-container",
                   show(View.BuildSettings))(
                 BuildSettings(state, backend)
               ),
@@ -59,7 +54,6 @@ object MainPanel {
               MobileBar(state, backend)
             )
           )
-        }
       }
       .build
 


### PR DESCRIPTION
Hi! Here you go, I hope this is helpful. If you're new to `Reusability` see [doc here](https://github.com/japgolly/scalajs-react/blob/master/doc/PERFORMANCE.md) for an explanation. Cheers!

---

In regards to scalajs-react usage, I forsee two styles of use becoming
problematic in future and would like to take this opportunity to
demonstrate an appealing alternative. The problems:

1. React's shouldComponentRender hooks are used to determine whether a
component tree need be rerendered, analysed and compared with previous
vdom. Scastie currently does not make use of this feature and so when
any change occurs anywhere on the screen, the entire page is
re-calculated.

2. Unit tests currently don't exist but are in the backlog. Most
components currently ask for much more data that they require, and in a
singular, specific form. This will make unit testing hard.

By applying best practices of minimising dependencies and using
generic forms, it becomes trivial to address both issues described
above.

Using `TopBar` as an example, this commit demonstrates:

* how to reduce component props to a minimal subset
* how `Reusability` can be used to avoid wasted re-calculation
* how `StateSnapshot` can be used to abstract away state ownership
* how to use `.when` on vdom for concise code and improved readability
  (an aside)

It also replaces `clazz` with `cls` for the dom `class` attribute, which
avoids the need for special handling in the import.