### PR TITLE
Redirect stderr to stdout (fix #284)

### DIFF
--- a/sbt-runner/src/main/scala/com.olegych.scastie.sbt/Sbt.scala
+++ b/sbt-runner/src/main/scala/com.olegych.scastie.sbt/Sbt.scala
@@ -49,7 +49,11 @@ class Sbt(defaultConfig: Inputs) {
 
   private val (process, fin, fout) = {
     log.info("Starting sbt process")
-    val builder = new ProcessBuilder("sbt").directory(sbtDir.toFile)
+    val builder = 
+      new ProcessBuilder("sbt")
+        .directory(sbtDir.toFile)
+        .redirectErrorStream(true)
+
     builder
       .environment()
       .put(
@@ -67,6 +71,8 @@ class Sbt(defaultConfig: Inputs) {
     val in = new BufferedReader(
       new InputStreamReader(process.getInputStream, StandardCharsets.UTF_8)
     )
+
+    process.getOutputStream
 
     (process, process.getOutputStream, in)
   }

--- a/sbt-runner/src/test/scala/com/olegych/scastie/sbt/EnsimeActorTests.scala
+++ b/sbt-runner/src/test/scala/com/olegych/scastie/sbt/EnsimeActorTests.scala
@@ -92,7 +92,7 @@ class EnsimeActorTests()
     )
   )
 
-  readyProbe.fishForMessage(1.minute) {
+  readyProbe.fishForMessage(3.minute) {
     case EnsimeReady => true
   }
 

--- a/sbt-runner/src/test/scala/com/olegych/scastie/sbt/SbtActorTest.scala
+++ b/sbt-runner/src/test/scala/com/olegych/scastie/sbt/SbtActorTest.scala
@@ -121,6 +121,17 @@ class SbtActorTest()
     run(scalaJs)(_.done)
   }
 
+  test("Capture System.err #284") {
+    val message = "Failure"
+    run(s"""System.err.println("$message")""")(progress => {
+      // we should only receive an hello message
+      val gotHelloMessage = progress.userOutput == Some(message)
+      if (!gotHelloMessage) assert(progress.userOutput.isEmpty)
+      gotHelloMessage
+    })
+
+  }
+
   def assertCompilationInfo(
       infoAssert: Problem => Any
   )(progress: SnippetProgress): Boolean = {
@@ -139,7 +150,7 @@ class SbtActorTest()
     TestKit.shutdownActorSystem(system)
   }
 
-  private val timeout = 20.seconds
+  private val timeout = 1.minute
   private val sbtActor = TestActorRef(
     new SbtActor(
       system = system,


### PR DESCRIPTION
* There is no distinction between stderr to stdout but it's a simple solution. Otherwise we need to start two threads the two streams
* Increase the test timeout to see if it fix travis ci