### PR TITLE
POC for Stainless

### DIFF
--- a/api/src/main/scala/com.olegych.scastie.api/Inputs.scala
+++ b/api/src/main/scala/com.olegych.scastie.api/Inputs.scala
@@ -108,6 +108,9 @@ case class Inputs(
 
         case _: ScalaTarget.Typelevel =>
           ""
+
+        case ScalaTarget.Stainless =>
+          ""
       }
 
     s"""|$targetConfig
@@ -185,6 +188,12 @@ case class Inputs(
                 buildVersion
               )
             )
+          )
+
+        case ScalaTarget.Stainless =>
+          (
+            """/* ??? */""",
+            None
           )
       }
 

--- a/api/src/main/scala/com.olegych.scastie.api/ScalaTarget.scala
+++ b/api/src/main/scala/com.olegych.scastie.api/ScalaTarget.scala
@@ -178,5 +178,16 @@ object ScalaTarget {
     override def toString: String = "Dotty"
   }
 
+  case object Stainless extends ScalaTarget {
+    def default: ScalaTarget = this
+
+    def targetType = ScalaTargetType.Stainless
+    def scaladexRequest = Map("target" -> "Stainless")
+    def renderSbt(lib: ScalaDependency): String = {
+      import lib._
+      s""""$groupId" %% "$artifact" % "$version""""
+    }
+  }
+
   implicit val pkl: ReadWriter[ScalaTarget] = upickleMacroRW[ScalaTarget]
 }

--- a/api/src/main/scala/com.olegych.scastie.api/ScalaTargetType.scala
+++ b/api/src/main/scala/com.olegych.scastie.api/ScalaTargetType.scala
@@ -14,6 +14,7 @@ object ScalaTargetType {
       case "JS"        => Some(JS)
       case "NATIVE"    => Some(Native)
       case "TYPELEVEL" => Some(Typelevel)
+      case "STAINLESS" => Some(Stainless)
       case _           => None
     }
   }
@@ -36,5 +37,9 @@ object ScalaTargetType {
 
   case object Typelevel extends ScalaTargetType {
     def defaultScalaTarget: ScalaTarget = ScalaTarget.Typelevel.default
+  }
+
+  case object Stainless extends ScalaTargetType {
+    def defaultScalaTarget: ScalaTarget = ScalaTarget.Stainless.default
   }
 }

--- a/build.sbt
+++ b/build.sbt
@@ -31,6 +31,8 @@ def akka(module: String) = "com.typesafe.akka" %% ("akka-" + module) % "2.5.2"
 
 def akkaHttp = "com.typesafe.akka" %% "akka-http" % akkaHttpVersion
 def akkaHttpCore = "com.typesafe.akka" %% "akka-http-core" % akkaHttpVersion
+def json4s = "org.json4s" %% "json4s-native" % "3.5.2"
+
 
 lazy val scastie = project
   .in(file("."))
@@ -152,6 +154,7 @@ lazy val sbtRunner = project
       akka("remote"),
       akka("slf4j"),
       akkaHttp,
+      json4s,
       "com.geirsson" %% "scalafmt-core" % "1.1.0",
       // sbt-ensime 1.12.13 creates .ensime with 2.0.0-SNAPSHOT server jar
       "org.ensime" %% "jerky" % "2.0.0-SNAPSHOT",

--- a/client/src/main/scala/com.olegych.scastie.client/components/BuildSettings.scala
+++ b/client/src/main/scala/com.olegych.scastie.client/components/BuildSettings.scala
@@ -36,7 +36,8 @@ object BuildSettings {
       ScalaTargetType.JVM,
       ScalaTargetType.Dotty,
       ScalaTargetType.Typelevel,
-      ScalaTargetType.JS //,
+      ScalaTargetType.JS,
+      ScalaTargetType.Stainless
       // ScalaTargetType.Native
     )
 
@@ -47,6 +48,7 @@ object BuildSettings {
         case ScalaTargetType.Dotty     => "Dotty"
         case ScalaTargetType.Native    => "Native"
         case ScalaTargetType.Typelevel => "Typelevel"
+        case ScalaTargetType.Stainless => "Stainless"
       }
     }
 
@@ -151,6 +153,9 @@ object BuildSettings {
           notSupported
 
         case ScalaTarget.Native(_, _) =>
+          notSupported
+
+        case ScalaTarget.Stainless =>
           notSupported
       }
 

--- a/sbt-runner/src/main/resources/application.conf
+++ b/sbt-runner/src/main/resources/application.conf
@@ -5,7 +5,7 @@ com.olegych.scastie {
     akka-port = 5150
     akka-port = ${?RUNNER_PORT}
 
-    runTimeout = 30s
+    runTimeout = 10s
     production = false
     production = ${?RUNNER_PRODUCTION}
   }

--- a/sbt-runner/src/main/resources/application.conf
+++ b/sbt-runner/src/main/resources/application.conf
@@ -5,7 +5,7 @@ com.olegych.scastie {
     akka-port = 5150
     akka-port = ${?RUNNER_PORT}
 
-    runTimeout = 10s
+    runTimeout = 60s
     production = false
     production = ${?RUNNER_PRODUCTION}
   }

--- a/sbt-runner/src/main/scala/com.olegych.scastie.sbt/SbtRunner.scala
+++ b/sbt-runner/src/main/scala/com.olegych.scastie.sbt/SbtRunner.scala
@@ -191,7 +191,7 @@ class SbtRunner(runTimeout: FiniteDuration, production: Boolean) extends Actor {
                     .copy(
                       snippetId = Some(snippetId),
                       timeout = false,
-                      done = false,
+                      done = true,
                       compilationInfos = List(
                         Problem(
                           Error,


### PR DESCRIPTION
This is a quick and dirty implementation to run Stainless in Scastie. This PR should therefore be closed, especially since it conflicts with recent changes. It's purpose is to advertise the possibility of getting static analysis in Scastie.

A few things should be reconsidered when working on a proper implementation.

 1. `compilationRequired` should not be required to be false for the stainless runtime. Instead, stainless' library should be made available to Scastie and a regular Scala compiler could be used to ensure the validity on the user input. Do note however that stainless will also compile the input code. It should therefore be possible to reduce the computation a bit.
 1. Currently stainless is shamelessly invoked through a Process. There are a few issues with this. The first of which is the design: it means that we need to write and then read a JSON file from disk. It also means that (w.r.t. to the previous point) if the user program is not valid, Scastie cannot get the compilation error without tediously parsing the error stream. There are also some technical issues such as not killing the process upon timeout/crash/...

Further development to stainless will also allow quicker response-time when re-verifying similar programs by leveraging caches.