### PR TITLE
Bump sbt-scalajs-bundler to real version.

### DIFF
--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -12,4 +12,4 @@ unmanagedSourceDirectories in Compile += {
 // addSbtPlugin("ch.epfl.scala" % "sbt-scalafix" % "0.5.0-RC2")
 
 // # see CONTRIBUTING.md
-addSbtPlugin("ch.epfl.scala" % "sbt-scalajs-bundler" % "0.9.0-SNAPSHOT")
+addSbtPlugin("ch.epfl.scala" % "sbt-scalajs-bundler" % "0.9.0")


### PR DESCRIPTION
I found out sbt-scalajs-bundler 0.9.0-SNAPSHOT is no longer existed. The real version number [already released](https://github.com/scalacenter/scalajs-bundler/blob/master/manual/src/ornate/changelog.md#version-090). So I updated to real version. 