### PR TITLE
2.11.9 and 2.11.10 were withdrawn.

### DIFF
--- a/api/src/main/scala/com.olegych.scastie.api/ScalaVersions.scala
+++ b/api/src/main/scala/com.olegych.scastie.api/ScalaVersions.scala
@@ -17,8 +17,10 @@ object ScalaVersions {
     "2.12.0-M1",
     "2.11.12",
     "2.11.11",
+    /* Those two versions were withdrawn.
     "2.11.10",
     "2.11.9",
+     */
     "2.11.8",
     "2.11.7",
     "2.11.6",


### PR DESCRIPTION
Original comment - https://github.com/scalacenter/scastie/pull/369#issuecomment-349693246
Github Release Note - https://github.com/scala/scala/releases/tag/v2.11.11
Relative ticket - https://github.com/scala/scala-dev/issues/385