### PR TITLE
Fix build.sbt is mis-formatted issue.

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -55,7 +55,7 @@ lazy val ciAlias =
         // "utils/test"
         // "balancer/test",
         // "sbtRunner/test"
-        
+
         // "ensimeRunner/test"
       )
     )


### PR DESCRIPTION
Run `bin/scalafmt --test` will throw the execption.

```scala
Exception in thread "main" org.scalafmt.Error$MisformattedFile: /home/travis/build/scalacenter/scastie/build.sbt is mis-formatted. 
```