### PR TITLE
Setup Proxy Repositories (fix #373)

### DIFF
--- a/project/DockerHelper.scala
+++ b/project/DockerHelper.scala
@@ -63,6 +63,16 @@ object DockerHelper {
 
     Files.write(globalPlugins, plugins.getBytes)
 
+    val repositories = sbtTargetDir.resolve("repositories")
+
+    val repositoriesConfig =
+      s"""|[repositories]
+          |local
+          |my-ivy-proxy-releases: http://scala-webapps.epfl.ch:8081/artifactory/scastie-ivy/, [organization]/[module]/(scala_[scalaVersion]/)(sbt_[sbtVersion]/)[revision]/[type]s/[artifact](-[classifier]).[ext]
+          |my-maven-proxy-releases: http://scala-webapps.epfl.ch:8081/artifactory/scastie-maven/""".stripMargin
+
+    Files.write(repositories, repositoriesConfig.getBytes)
+
     new Dockerfile {
       from("openjdk:8u131-jdk-alpine")
 


### PR DESCRIPTION
Since sbt instances are separated in their own docker containers, they don't share an artifact cache. Also, when we deploy a new container, all the artifact cache is thrown away.

Sbt Docs:
http://www.scala-sbt.org/0.13/docs/Proxy-Repositories.html

Manual Steps
1. Install artifactory
2. Add remote repository [2]
  (ivy) typesafe-ivy-releases: http://repo.typesafe.com/typesafe/ivy-releases/
  (ivy) sbt-plugin-releases: https://dl.bintray.com/sbt/sbt-plugin-releases/
3. Create two virtual repositories [3]
  scastie-ivy (with typesafe-ivy-releases and sbt-plugin-releases)
  scastie-maven (with maven-central)
4. suppress POM consistency checks for maven-central [4] [4a]

[2]: http://scala-webapps.epfl.ch:8081/artifactory/webapp/#/admin/repositories/remote
[3]: http://scala-webapps.epfl.ch:8081/artifactory/webapp/#/admin/repository/virtual/new
[4]: http://scala-webapps.epfl.ch:8081/artifactory/webapp/#/admin/repository/remote/central/edit
[4a]: found in https://github.com/coursier/coursier/issues/286