### PR TITLE
replaced deprocated ActorPublisher with GraphStage.

### DIFF
--- a/balancer/src/main/scala/com.olegych.scastie.balancer/ProgressActor.scala
+++ b/balancer/src/main/scala/com.olegych.scastie.balancer/ProgressActor.scala
@@ -117,8 +117,7 @@ class ProgressActor extends Actor {
         queuedMessages += (snippetId -> queue)
     }
 
-  private def sendQueuedMessages(snippetId: SnippetId,
-                                     self: ActorRef): Unit =
+  private def sendQueuedMessages(snippetId: SnippetId, self: ActorRef): Unit =
     for {
       messageQueue <- queuedMessages.get(snippetId).toSeq
       (_, Some(graphStageForwarderActor)) <- subscribers.get(snippetId).toSeq

--- a/utils/src/main/scala/com.olegych.scastie/util/GraphStageForwarder.scala
+++ b/utils/src/main/scala/com.olegych.scastie/util/GraphStageForwarder.scala
@@ -1,0 +1,18 @@
+package com.olegych.scastie.util
+
+import akka.actor.ActorRef
+import akka.stream.{Attributes, Outlet, SourceShape}
+import akka.stream.stage.{GraphStage, GraphStageLogic}
+
+import scala.reflect.runtime.universe._
+
+class GraphStageForwarder[T: TypeTag, U: TypeTag](
+    outletName: String,
+    coordinator: ActorRef,
+    graphId: U
+) extends GraphStage[SourceShape[T]] {
+  val out: Outlet[T] = Outlet(outletName)
+  override val shape = SourceShape[T](out)
+  override def createLogic(inheritedAttributes: Attributes): GraphStageLogic =
+    new GraphStageLogicForwarder(out, shape, coordinator, graphId)
+}

--- a/utils/src/main/scala/com.olegych.scastie/util/GraphStageLogicForwarder.scala
+++ b/utils/src/main/scala/com.olegych.scastie/util/GraphStageLogicForwarder.scala
@@ -9,9 +9,9 @@ import scala.util.Try
 import scala.reflect.runtime.universe._
 
 class GraphStageLogicForwarder[T: TypeTag, U: TypeTag](out: Outlet[T],
-                                                         shape: SourceShape[T],
-                                                         coordinator: ActorRef,
-                                                         graphId: U)
+                                                       shape: SourceShape[T],
+                                                       coordinator: ActorRef,
+                                                       graphId: U)
     extends GraphStageLogic(shape) {
 
   setHandler(

--- a/utils/src/main/scala/com.olegych.scastie/util/GraphStageLogicForwarder.scala
+++ b/utils/src/main/scala/com.olegych.scastie/util/GraphStageLogicForwarder.scala
@@ -1,0 +1,46 @@
+package com.olegych.scastie.util
+
+import akka.actor.ActorRef
+import akka.stream.{Outlet, SourceShape}
+import akka.stream.stage.{GraphStageLogic, OutHandler}
+
+import scala.collection.mutable.{Queue => MQueue}
+import scala.util.Try
+import scala.reflect.runtime.universe._
+
+class GraphStageLogicForwarder[T: TypeTag, U: TypeTag](out: Outlet[T],
+                                                         shape: SourceShape[T],
+                                                         coordinator: ActorRef,
+                                                         graphId: U)
+    extends GraphStageLogic(shape) {
+
+  setHandler(
+    out,
+    new OutHandler {
+      override def onPull(): Unit = {
+        deliver()
+      }
+    }
+  )
+
+  override def preStart(): Unit = {
+    val thisGraphStageActorRef = getStageActor(bufferElement).ref
+    coordinator ! ((graphId, thisGraphStageActorRef))
+  }
+
+  private val buffer = MQueue.empty[T]
+
+  private def deliver(): Unit = if (isAvailable(out)) {
+    Try(buffer.dequeue).foreach { element =>
+      push[T](out, element)
+    }
+  }
+
+  private def bufferElement(receive: (ActorRef, Any)): Unit =
+    receive match {
+      case (_, element: T) =>
+        buffer.enqueue(element)
+        deliver()
+    }
+
+}


### PR DESCRIPTION
The ```com.olegych.scastie.util.GraphStageForwarder``` class is created to replace ```com.olegych.scastie.util.ActorForwarder```.

Similarities between ActorForwarder and GraphStageForwarder: 
  * Both of them can be used to create a Source object.
  * Both of them return an ActorRef to be used to send messages that will be forwarded to the created Source.

The difference:
  * after the creation of a the GraphStageForwarder, its ActorRef will be sent asynchronously to the ```GraphStageForwarder.coordinator``` parameter along with the ```GraphStageForwarder.graphId``` parameter.

This means that an ```com.olegych.scastie.balancer.ProgressActor``` object needs to queue all the received SnippetProgress until it receives the appropriate GraphStage's ActorRef, which will happen when the ```GraphStage.createLogic.onPreStart()``` function is triggered.


