### PR TITLE
Upgrade Dotty to 3.0.0-M1

### DIFF
--- a/project/SbtShared.scala
+++ b/project/SbtShared.scala
@@ -22,7 +22,7 @@ object SbtShared {
     val latest211 = "2.11.12"
     val latest212 = "2.12.12"
     val latest213 = "2.13.3"
-    val latestDotty = "0.27.0-RC1"
+    val latestDotty = "3.0.0-M1"
     val js = latest213
     val sbt = latest212
     val jvm = latest213


### PR DESCRIPTION
This probably won't work out of the box due to the recent artefact naming conventions change. See https://contributors.scala-lang.org/t/dotty-artefacts-naming-change/4532