### PR TITLE
Support multiple Scala3 versions, including stable

### DIFF
--- a/api/src/main/scala/com.olegych.scastie.api/ScalaTarget.scala
+++ b/api/src/main/scala/com.olegych.scastie.api/ScalaTarget.scala
@@ -273,7 +273,7 @@ object ScalaTarget {
   }
 
   object Scala3 {
-    def default: ScalaTarget = Scala3(BuildInfo.latest3)
+    def default: ScalaTarget = Scala3(BuildInfo.stable3)
 
     def defaultCode: String =
       """|// You can find more examples here:

--- a/api/src/main/scala/com.olegych.scastie.api/ScalaVersions.scala
+++ b/api/src/main/scala/com.olegych.scastie.api/ScalaVersions.scala
@@ -3,48 +3,63 @@ package com.olegych.scastie.api
 import com.olegych.scastie.buildinfo.BuildInfo
 
 object ScalaVersions {
-  val suggestedScalaVersions: List[String] = List(BuildInfo.latest213, BuildInfo.latest212)
+  def suggestedScalaVersions(tpe: ScalaTargetType): List[String] = tpe match {
+    case ScalaTargetType.Scala3 => List(BuildInfo.stable3, BuildInfo.latest3)
+    case _ => List(BuildInfo.latest213, BuildInfo.latest212)
+  }
+  
+  def allVersions(tpe: ScalaTargetType): List[String] = tpe match {
+    case ScalaTargetType.Scala3 => List(
+      BuildInfo.stable3,
+      BuildInfo.latest3,
+      "3.0.0-RC3",
+      "3.0.0-RC2",
+      "3.0.0-RC1",
+      "3.0.0-M3",
+      "3.0.0-M1"
+    )
+    case _ => List(
+      BuildInfo.latest213,
+      "2.13.5",
+      "2.13.4",
+      "2.13.3",
+      "2.13.2",
+      "2.13.1",
+      "2.13.0",
+      BuildInfo.latest212,
+      "2.12.12",
+      "2.12.11",
+      "2.12.10",
+      "2.12.9",
+      "2.12.8",
+      "2.12.7",
+      "2.12.6",
+      "2.12.5",
+      "2.12.4",
+      "2.12.3",
+      "2.12.2",
+      "2.12.1",
+      "2.12.0",
+      BuildInfo.latest211,
+      "2.11.11",
+      /* Those two versions were withdrawn.
+      "2.11.10",
+      "2.11.9",
+      */
+      "2.11.8",
+      "2.11.7",
+      "2.11.6",
+      "2.11.5",
+      "2.11.4",
+      "2.11.3",
+      "2.11.2",
+      "2.11.1",
+      "2.11.0",
+      BuildInfo.latest210,
+      "2.10.6"
+    )
+  }
 
-  val allVersions: List[String] = List(
-    BuildInfo.latest213,
-    "2.13.5",
-    "2.13.4",
-    "2.13.3",
-    "2.13.2",
-    "2.13.1",
-    "2.13.0",
-    BuildInfo.latest212,
-    "2.12.12",
-    "2.12.11",
-    "2.12.10",
-    "2.12.9",
-    "2.12.8",
-    "2.12.7",
-    "2.12.6",
-    "2.12.5",
-    "2.12.4",
-    "2.12.3",
-    "2.12.2",
-    "2.12.1",
-    "2.12.0",
-    BuildInfo.latest211,
-    "2.11.11",
-    /* Those two versions were withdrawn.
-    "2.11.10",
-    "2.11.9",
-     */
-    "2.11.8",
-    "2.11.7",
-    "2.11.6",
-    "2.11.5",
-    "2.11.4",
-    "2.11.3",
-    "2.11.2",
-    "2.11.1",
-    "2.11.0",
-    BuildInfo.latest210,
-    "2.10.6"
-  )
-
-  def find(sv: String): String = allVersions.find(_.startsWith(sv)).getOrElse(sv)
+  def find(tpe: ScalaTargetType, sv: String): String = 
+    allVersions(tpe).find(_.startsWith(sv)).getOrElse(sv)
 }

--- a/client/src/main/scala/com.olegych.scastie.client/Routing.scala
+++ b/client/src/main/scala/com.olegych.scastie.client/Routing.scala
@@ -42,13 +42,13 @@ class Routing(defaultServerUrl: String) {
         case (Some(g), Some(a), Some(v), o, r) =>
           val target =
             map.get("t").flatMap(ScalaTargetType.parse) match {
-              case Some(ScalaTargetType.Scala2) =>
-                map.get("sv").map(sv => ScalaTarget.Jvm(ScalaVersions.find(sv)))
+              case Some(t@ScalaTargetType.Scala2) =>
+                map.get("sv").map(sv => ScalaTarget.Jvm(ScalaVersions.find(t, sv)))
 
-              case Some(ScalaTargetType.JS) =>
+              case Some(t@ScalaTargetType.JS) =>
                 (map.get("sv"), map.get("sjsv")) match {
                   case (Some(sv), sjsv) =>
-                    Some(ScalaTarget.Js(ScalaVersions.find(sv), sjsv.getOrElse(ScalaTarget.Js.default.scalaJsVersion)))
+                    Some(ScalaTarget.Js(ScalaVersions.find(t, sv), sjsv.getOrElse(ScalaTarget.Js.default.scalaJsVersion)))
                   case _ => None
                 }
 

--- a/client/src/main/scala/com.olegych.scastie.client/components/BuildSettings.scala
+++ b/client/src/main/scala/com.olegych.scastie.client/components/BuildSettings.scala
@@ -93,7 +93,7 @@ object BuildSettings {
 
       TagMod(
         ul(cls := "suggestedVersions")(
-          ScalaVersions.suggestedScalaVersions.map { suggestedVersion =>
+          ScalaVersions.suggestedScalaVersions(props.scalaTarget.targetType).map { suggestedVersion =>
             li(
               input(`type` := "radio",
                     id := s"scala-$suggestedVersion",
@@ -109,7 +109,7 @@ object BuildSettings {
             label(
               div(cls := "select-wrapper")(
                 select(name := "scalaVersion", value := scalaVersion.toString, onChange ==> setScalaVersion(targetFun))(
-                  ScalaVersions.allVersions
+                  ScalaVersions.allVersions(props.scalaTarget.targetType)
                     .map(version => option(version))
                     .toTagMod
                 )
@@ -129,7 +129,7 @@ object BuildSettings {
           versionSelector(scalaVersion, ScalaTarget.Typelevel.apply)
 
         case d: ScalaTarget.Scala3 =>
-          div(d.dottyVersion)
+          versionSelector(d.dottyVersion, ScalaTarget.Scala3.apply)
 
         case js: ScalaTarget.Js =>
           div(s"${js.scalaJsVersion} on Scala ${js.scalaVersion}")

--- a/project/SbtShared.scala
+++ b/project/SbtShared.scala
@@ -22,6 +22,7 @@ object SbtShared {
     val latest211 = "2.11.12"
     val latest212 = "2.12.13"
     val latest213 = "2.13.6"
+    val stable3   = "3.0.0"
     val latest3   = "3.0.1-RC1"
     val js = latest213
     val sbt = latest212
@@ -173,6 +174,7 @@ object SbtShared {
         "latest211" -> ScalaVersions.latest211,
         "latest212" -> ScalaVersions.latest212,
         "latest213" -> ScalaVersions.latest213,
+        "stable3"   -> ScalaVersions.stable3,
         "latest3"   -> ScalaVersions.latest3,
         "jsScalaVersion" -> ScalaVersions.js,
         "defaultScalaJsVersion" -> ScalaJSVersions.current,


### PR DESCRIPTION
The scastie version currently deployed allows the user to choose only 1 version for Scala 3 and it is not 3.0.0 but 3.0.1-RC1.
This PR introduces support for multiple Scala 3 versions in the user interface reusing the same strategy used for Scala 2