### PR TITLE
Search artifacts for Scala 3 instead of always crossing 2.13

### DIFF
--- a/api/src/main/scala/com.olegych.scastie.api/ScalaTarget.scala
+++ b/api/src/main/scala/com.olegych.scastie.api/ScalaTarget.scala
@@ -260,27 +260,25 @@ object ScalaTarget {
          |""".stripMargin
   }
 
-  case class Scala3(dottyVersion: String) extends ScalaTarget {
-    def scalaVersion = dottyVersion
-
+  case class Scala3(scalaVersion: String) extends ScalaTarget {
     def targetType: ScalaTargetType =
       ScalaTargetType.Scala3
 
     def scaladexRequest: Map[String, String] =
-      Map("target" -> "JVM", "scalaVersion" -> "2.13")
+      Map("target" -> "JVM", "scalaVersion" -> scalaVersion)
 
     def renderSbt(lib: ScalaDependency): String =
       if (Some(lib) == runtimeDependency) renderSbtDouble(lib)
       else s"${renderSbtDouble(lib)} cross CrossVersion.for3Use2_13"
 
     def sbtConfig: String =
-      sbtConfigScalaVersion(dottyVersion)
+      sbtConfigScalaVersion(scalaVersion)
 
     def sbtPluginsConfig: String = ""
 
     def sbtRunCommand(worksheetMode: Boolean): String = if (worksheetMode) "fgRunMain Main" else "fgRun"
 
     override def toString: String =
-      s"Scala $dottyVersion"
+      s"Scala $scalaVersion"
   }
 }

--- a/client/src/main/scala/com.olegych.scastie.client/components/BuildSettings.scala
+++ b/client/src/main/scala/com.olegych.scastie.client/components/BuildSettings.scala
@@ -125,7 +125,7 @@ object BuildSettings {
         case d: ScalaTarget.Typelevel =>
           versionSelector(d.scalaVersion, ScalaTarget.Typelevel.apply)
         case d: ScalaTarget.Scala3 =>
-          versionSelector(d.scala3version, ScalaTarget.Scala3.apply)
+          versionSelector(d.scalaVersion, ScalaTarget.Scala3.apply)
 
         case js: ScalaTarget.Js =>
           versionSelector(js.scalaVersion, sv => ScalaTarget.Js(sv, js.scalaJsVersion))

--- a/client/src/main/scala/com.olegych.scastie.client/components/BuildSettings.scala
+++ b/client/src/main/scala/com.olegych.scastie.client/components/BuildSettings.scala
@@ -125,7 +125,8 @@ object BuildSettings {
         case d: ScalaTarget.Typelevel =>
           versionSelector(d.scalaVersion, ScalaTarget.Typelevel.apply)
         case d: ScalaTarget.Scala3 =>
-          versionSelector(d.scalaVersion, ScalaTarget.Scala3.apply)
+          versionSelector(d.scala3version, ScalaTarget.Scala3.apply)
+
         case js: ScalaTarget.Js =>
           versionSelector(js.scalaVersion, sv => ScalaTarget.Js(sv, js.scalaJsVersion))
         case n: ScalaTarget.Native =>

--- a/client/src/main/scala/com.olegych.scastie.client/components/ScaladexSearch.scala
+++ b/client/src/main/scala/com.olegych.scastie.client/components/ScaladexSearch.scala
@@ -263,8 +263,8 @@ object ScaladexSearch {
             // If scala3 but no scala 3 versions available, offer 2.13 artifacts
             case Scala3(_) =>
               projsForThisTarget.flatMap { ls =>
-                if (ls.nonEmpty) Future(ls)
-                else queryAndParse(Jvm(BuildInfo.latest213))
+                queryAndParse(Jvm(BuildInfo.latest213))
+                  .map(arts213 => ls ::: arts213)
               }
             case _ => projsForThisTarget
           }

--- a/client/src/main/scala/com.olegych.scastie.client/components/ScaladexSearch.scala
+++ b/client/src/main/scala/com.olegych.scastie.client/components/ScaladexSearch.scala
@@ -100,7 +100,7 @@ object ScaladexSearch {
     }
   }
 
-  private val scaladexBaseUrl = "http://localhost:8087"
+  private val scaladexBaseUrl = "http://localhost:8080"
   //private val scaladexBaseUrl = "https://index.scala-lang.org"
   private val scaladexApiUrl = scaladexBaseUrl + "/api"
 
@@ -190,7 +190,6 @@ object ScaladexSearch {
       if (state.selecteds.exists(_.matches(project, artifact))) Callback(())
       else
         Callback.future {
-          println("TARGET IS " + target)
           fetchSelected(project, artifact, target, version).map {
             case Some(selected) if !state.selecteds.exists(_.release.matches(selected.release)) =>
               def addScalaDependencyLocal =

--- a/client/src/main/scala/com.olegych.scastie.client/components/ScaladexSearch.scala
+++ b/client/src/main/scala/com.olegych.scastie.client/components/ScaladexSearch.scala
@@ -263,7 +263,7 @@ object ScaladexSearch {
             // If scala3 but no scala 3 versions available, offer 2.13 artifacts
             case Scala3(_) =>
               projsForThisTarget.flatMap { ls =>
-                if (ls.nonEmpty) projsForThisTarget
+                if (ls.nonEmpty) Future(ls)
                 else queryAndParse(Jvm(BuildInfo.latest213))
               }
             case _ => projsForThisTarget

--- a/client/src/main/scala/com.olegych.scastie.client/components/ScaladexSearch.scala
+++ b/client/src/main/scala/com.olegych.scastie.client/components/ScaladexSearch.scala
@@ -15,6 +15,7 @@ import dom.ext.Ajax
 import scalajs.concurrent.JSExecutionContext.Implicits.queue
 import scala.concurrent.Future
 import com.olegych.scastie.api.ScalaTarget.{Jvm, Scala3}
+import com.olegych.scastie.buildinfo.BuildInfo
 
 final case class ScaladexSearch(
     removeScalaDependency: ScalaDependency ~=> Callback,
@@ -100,8 +101,8 @@ object ScaladexSearch {
     }
   }
 
-  private val scaladexBaseUrl = "http://localhost:8080"
-  //private val scaladexBaseUrl = "https://index.scala-lang.org"
+  // private val scaladexBaseUrl = "http://localhost:8080"
+  private val scaladexBaseUrl = "https://index.scala-lang.org"
   private val scaladexApiUrl = scaladexBaseUrl + "/api"
 
   private implicit val projectOrdering: Ordering[Project] =
@@ -263,7 +264,7 @@ object ScaladexSearch {
             case Scala3(_) =>
               projsForThisTarget.flatMap { ls =>
                 if (ls.nonEmpty) projsForThisTarget
-                else queryAndParse(Jvm.default)
+                else queryAndParse(Jvm(BuildInfo.latest213))
               }
             case _ => projsForThisTarget
           }

--- a/client/src/main/scala/com.olegych.scastie.client/components/ScaladexSearch.scala
+++ b/client/src/main/scala/com.olegych.scastie.client/components/ScaladexSearch.scala
@@ -352,7 +352,7 @@ object ScaladexSearch {
               img(src := Assets.placeholderUrl, common, alt := s"placeholder logo for $organization")
             ),
           span(cls := "artifact")(label),
-          if (scalaTarget != props.scalaTarget) span(cls := "artifact")(s"cross from ${scalaTarget} ") else ""
+          if (scalaTarget != props.scalaTarget) span(cls := "artifact")(s"(${scalaTarget} artifacts)") else ""
         ),
         options
       )


### PR DESCRIPTION
Is this with https://github.com/scalacenter/scaladex/pull/687 enough to fix #514 ?
I am not sure about https://github.com/vincenzobaz/scastie/blob/8f11f31673a482c5c4d109c685c66e1811cf1d71/api/src/main/scala/com.olegych.scastie.api/ScalaTarget.scala#L269