### PR TITLE
Add support for latest scala 3.0.2-RC1, closes #518

### DIFF
--- a/project/SbtShared.scala
+++ b/project/SbtShared.scala
@@ -23,7 +23,7 @@ object SbtShared {
     val latest212 = "2.12.13"
     val latest213 = "2.13.6"
     val stable3   = "3.0.1"
-    val latest3   = "3.0.1"
+    val latest3   = "3.0.2-RC1"
     val js = latest213
     val sbt = latest212
     val jvm = latest213


### PR DESCRIPTION
I hope that is how "latest3" is intended to be used (i.e. for the current latest RC), it seems this is how it has been for 3.0.0 and 3.0.1-RC2 at least
closes #518  