### PR TITLE
Make value rendering null-safe

### DIFF
--- a/runtime-scala/src/main/scala/com.olegych.scastie.api.runtime/SharedRuntime.scala
+++ b/runtime-scala/src/main/scala/com.olegych.scastie.api.runtime/SharedRuntime.scala
@@ -10,11 +10,15 @@ protected[runtime] trait SharedRuntime {
 
   private val maxValueLength = 500
 
+  private def show[A](a: A): String =
+    if(a == null) "null"
+    else a.toString
+
   protected[runtime] def render[T](a: T, typeName: String): Render = {
     a match {
       case html: Html => html
       case v =>
-        val vs = v.toString
+        val vs = show(v)
         val out =
           if (vs.size > maxValueLength) vs.take(maxValueLength) + "..."
           else vs


### PR DESCRIPTION
This is a fix for https://github.com/scalacenter/scastie/issues/534.

I haven't written any test, because it looks like `SharedRuntime` isn't tested anywhere, so I assumed it was more of an "if it works empirically, that's good enough for us".

If the maintainers need tests, I'd be happy to add them but would require a little bit of help getting started with setting them up. I'm not at all familiar with the project's internal.