### PR TITLE
Run on Java 17

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -13,4 +13,4 @@ jobs:
     - uses: nixbuild/nix-quick-install-action@v5
     - name: Run tests
       run: |
-        nix-shell -A scastie --command  "sbt -DSnippetsContainerTest.mongo=true cachedCiTest"
+        nix-shell --command "sbt -DSnippetsContainerTest.mongo=true cachedCiTest"

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -9,12 +9,12 @@ You are more than welcome to contribute any PR regardless if it's listed or not.
 
 ```
 curl https://nixos.org/nix/install | sh
-nix-shell -A scastie
+nix-shell
 ```
 
 ### How to install prerequisites on Mac
 ```
-brew install openjdk sbt nodejs yarn
+brew install openjdk@17 sbt nodejs yarn
 ```
 
 ### How to install prerequisites on Windows
@@ -25,7 +25,7 @@ git config --add core.symlinks true
 git reset --hard HEAD
 ```
 ```
-choco install nvm yarn sbt jdk8 python3
+choco install nvm yarn sbt openjdk17 python3
 nvm install 8.9.1
 nvm use 8.9.1
 ```

--- a/default.nix
+++ b/default.nix
@@ -1,57 +1,18 @@
-let
-  pkgs = import (builtins.fetchGit {
-      name = "pinned-pkgs";
-      url = "https://github.com/nixos/nixpkgs-channels/";
-      ref = "refs/heads/nixpkgs-unstable";
-      rev = "92a047a6c4d46a222e9c323ea85882d0a7a13af8";
-  }) {};
-  stdenv = pkgs.stdenv;
-  sbt = pkgs.callPackage sbt.nix { };
-  jre = pkgs.jre;
-  fetchurl = pkgs.fetchurl;
-in rec {
-  scastie = stdenv.mkDerivation rec {
-    SBT_OPTS = "-Xms512m -Xmx1024M";
-    name = "sbt-env";
-    shellHook = ''
+with import (builtins.fetchGit {
+  name = "nixos-unstable-2021-11-15";
+  url = "https://github.com/nixos/nixpkgs/";
+  ref = "refs/heads/nixos-unstable";
+  rev = "931ab058daa7e4cd539533963f95e2bb0dbd41e6";
+}) {};
+  
+stdenv.mkDerivation {
+  name = "scastie";
+
+  buildInputs = with pkgs; [ sbt nodejs yarn bash ];
+
+  SBT_OPTS = "-Xms512m -Xmx1024M";
+
+  shellHook = ''
     alias cls=clear
-    '';
-    buildInputs = [
-      pkgs.openjdk
-      sbt
-      pkgs.nodejs
-      pkgs.yarn
-      pkgs.bash
-    ];
-  };
-
-  sbt = stdenv.mkDerivation rec {
-    name = "sbt-${version}";
-    version = "1.5.5";
- 
-    src = fetchurl {
-      url = "https://github.com/sbt/sbt/releases/download/v${version}/sbt-${version}.tgz";
-      sha256 = "c0fcd50cf5c91ed27ad01c5c6a8717b62700c87a50ff9b0e7573b227acb2b3c9";
-      name = "sbt.tgz";
-    };
-
-    patchPhase = ''
-      echo -java-home ${jre.home} >>conf/sbtopts
-    '';
-
-    installPhase = ''
-      mkdir -p $out/share/sbt $out/bin
-      cp -ra . $out/share/sbt
-      ln -s $out/share/sbt/bin/sbt $out/bin/
-    '';
-
-    meta = with stdenv.lib; {
-      homepage = http://www.scala-sbt.org/;
-      license = licenses.bsd3;
-      description = "A build tool for Scala, Java and more";
-      maintainers = with maintainers; [ rickynils ];
-      platforms = platforms.unix;
-    };
-  };
-
-}
+  '';
+ }

--- a/project/DockerHelper.scala
+++ b/project/DockerHelper.scala
@@ -47,7 +47,7 @@ object DockerHelper {
     sbtGlobal.toFile.mkdirs()
 
     new Dockerfile {
-      from("openjdk:8u171-jdk-alpine")
+      from("openjdk:17-alpine")
 
       // Install ca-certificates for wget https
       runRaw("apk update")

--- a/utils/src/main/scala/com.olegych.scastie/util/BlockingProcess.scala
+++ b/utils/src/main/scala/com.olegych.scastie/util/BlockingProcess.scala
@@ -17,13 +17,11 @@ import scala.concurrent.duration.Duration
 
 object BlockingProcess {
 
-  def getPid(process: JavaProcess): Option[Int] = {
+  def getPid(process: JavaProcess): Option[Long] = {
     if (Helpers.isWindows) {
       None
     } else {
-      val pidField = process.getClass.getDeclaredField("pid")
-      pidField.setAccessible(true)
-      Some(pidField.get(process).asInstanceOf[Int])
+      Some(process.pid())
     }
   }
 
@@ -42,7 +40,7 @@ object BlockingProcess {
    * @param stdout a `akka.stream.scaladsl.Source[ByteString, Future[IOResult]]` for the standard output stream of the process
    * @param stderr a `akka.stream.scaladsl.Source[ByteString, Future[IOResult]]` for the standard error stream of the process
    */
-  case class Started(pid: Option[Int],
+  case class Started(pid: Option[Long],
                      stdin: Sink[ByteString, Future[IOResult]],
                      stdout: Source[ByteString, Future[IOResult]],
                      stderr: Source[ByteString, Future[IOResult]])


### PR DESCRIPTION
Things done:

 - Update JDK packages in `CONTRIBUTING.md` installation instructions,
 - use a recent snapshot of `nixos-unstable`,
 - simplify `default.nix`,
 - update runner base image and
 - replace no longer supported use process PID via reflection with
   the `.pid()` getter.

I tested this locally with `startAll` and by using the runner in the Docker container and it seems to work but I may well have missed something.