### PR TITLE
Add stats collection

### DIFF
--- a/client/src/main/resources/prod.html
+++ b/client/src/main/resources/prod.html
@@ -11,6 +11,7 @@
     <meta name="description" content="Scastie can run any Scala program with any library in your browser. You don’t need to download or install anything.">
 
     <meta name="viewport" content="width=device-width, initial-scale=1">
+    <script defer data-domain="scastie.scala-lang.org" src="https://plausible.scala-lang.org/js/script.js"></script>
   </head>
 
   <body>


### PR DESCRIPTION
This PR adds statistics collection to Scastie using a self hosted Plausible instance.

[Plausible](https://plausible.io/) is open source and privacy-friendly tool. All the data is stored on the Scala Center' servers.