### PR TITLE
Update to 1.5.7, to address CVE-2021-45046

### DIFF
--- a/project/build.properties
+++ b/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version=1.5.5
+sbt.version=1.5.7


### PR DESCRIPTION
Sbt 1.5.7 updates log4j 2 to 2.16.0, which disables JNDI lookup and fixes a denial of service vulnerability (CVE-2021-45046)

See: https://github.com/sbt/sbt/releases/tag/v1.5.7