### PR TITLE
add Scala 2.13.8

### DIFF
--- a/api/src/main/scala/com.olegych.scastie.api/ScalaVersions.scala
+++ b/api/src/main/scala/com.olegych.scastie.api/ScalaVersions.scala
@@ -27,6 +27,7 @@ object ScalaVersions {
       case _ =>
         List(
           BuildInfo.latest213,
+          "2.13.7",
           "2.13.6",
           "2.13.5",
           "2.13.4",

--- a/project/SbtShared.scala
+++ b/project/SbtShared.scala
@@ -20,7 +20,7 @@ object SbtShared {
     val latest210 = "2.10.7"
     val latest211 = "2.11.12"
     val latest212 = "2.12.15"
-    val latest213 = "2.13.7"
+    val latest213 = "2.13.8"
     val old3 = "3.0.2"
     val stable3 = "3.1.0"
     val latest3 = "3.1.1-RC1"


### PR DESCRIPTION
up to you if you want to merge it now (because 2.13.8 JARs are on Maven Central), or wait until the release is fully announced (hopefully Wednesday)