### PR TITLE
remove workaround which doesn't work on M1 Macs

### DIFF
--- a/.sbtopts
+++ b/.sbtopts
@@ -1,5 +1,3 @@
-#workaround for java17
--Djdk.lang.Process.launchMechanism=vfork
 -Dfile.encoding=UTF-8
 #less jerky heap freeing than Parallel, but may crash on java 8 < 181
 -J-XX:+UseG1GC


### PR DESCRIPTION
with this present, sbt won't start at all on my M1 Mac, regardless of whether I use JDK 8, 11, or 17

so whatever the disease was here, the cure seems to be worse