### PR TITLE
Don't emit jvm warnings and infos for scalajs output directory extraction

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "version": "0.0.0",
   "scripts": {
     "dev": "vite",
-    "build": "vite build && MODE=embed vite build -l error"
+    "build": "vite build && MODE=embed vite build"
   },
   "devDependencies": {
     "sass": "^1.55.0"

--- a/vite.config.js
+++ b/vite.config.js
@@ -11,7 +11,7 @@ function emitEmbedded() {
 }
 
 function printSbtTask(task) {
-  const args = ["--error", "--batch", `print ${task}`];
+  const args = ["-J-Xlog:all=error", "--error", "--batch", `print ${task}`];
   const options = {
     stdio: [
       "pipe", // StdIn.


### PR DESCRIPTION
JVM is emmiting warning when it is run inside nix-shell
[0.005s][warning][os,container] Duplicate cpuset controllers detected. Picking /sys/fs/cgroup/cpuset, skipping /tmp/nix-chroot.BeJFjH/sys/fs/cgroup/cpuset.

Adding `-J-Xlog:all=error` flag to the sbt process should suppress it and the deployment should be fixed.