### PR TITLE
Fix css for lint messages

### DIFF
--- a/client/src/main/resources/sass/tooltip.scss
+++ b/client/src/main/resources/sass/tooltip.scss
@@ -6,21 +6,26 @@
     font-size: 14px;
   }
 
-  .cm-tooltip {
-    .cm-completionInfo, &-hover > &:not(.cm-tooltip-lint) {
-      font-family: $font-family;
-      font-size: 14px;
-      min-width: 400px;
-      max-width: 500px;
-      max-height: 500px;
-      overflow-x: hidden;
-      ul {
-          list-style-type: disc;
-          line-height: 0.90em;
-          padding-inline-start: 1.5em;
-          padding: 0 0.7em 0.3em 1.3em;
-      }
+  .cm-completionInfo {
+    min-width: 400px;
+  }
+
+  .cm-completionInfo, .cm-tooltip-hover > :not(.cm-tooltip-lint) {
+    font-family: $font-family;
+    max-width: 600px !important;
+    overflow: auto;
+    max-height: 500px;
+    font-size: 14px;
+
+    ul {
+      list-style-type: disc;
+      line-height: 0.90em;
+      padding-inline-start: 1.5em;
+      padding: 0 0.7em 0.3em 1.3em;
     }
+  }
+
+  .cm-tooltip {
 
     @media only screen and (max-width: #{$mobile-width}) {
       min-width: 95%;
@@ -51,7 +56,7 @@
       margin: 0.5em 0;
     }
 
-    code:not(.language-scala){
+    code:not(.language-scala) {
       padding: 0 0.4em;
       background-color: $code-background-color;
       border-radius: 4px;

--- a/client/src/main/resources/sass/tooltip.scss
+++ b/client/src/main/resources/sass/tooltip.scss
@@ -8,11 +8,11 @@
 
   .cm-completionInfo {
     min-width: 400px;
+    max-width: 600px !important;
   }
 
   .cm-completionInfo, .cm-tooltip-hover > :not(.cm-tooltip-lint) {
     font-family: $font-family;
-    max-width: 600px !important;
     overflow: auto;
     max-height: 500px;
     font-size: 14px;
@@ -26,6 +26,7 @@
   }
 
   .cm-tooltip {
+    max-width: 70%;
 
     @media only screen and (max-width: #{$mobile-width}) {
       min-width: 95%;

--- a/client/src/main/resources/sass/tooltip.scss
+++ b/client/src/main/resources/sass/tooltip.scss
@@ -2,8 +2,12 @@
 @import "highlight.js/styles/base16/solarized-dark.css";
 
 @mixin tooltip($class) {
+  .cm-tooltip-lint {
+    font-size: 14px;
+  }
+
   .cm-tooltip {
-    .cm-completionInfo, &-hover {
+    .cm-completionInfo, &-hover > &:not(.cm-tooltip-lint) {
       font-family: $font-family;
       font-size: 14px;
       min-width: 400px;
@@ -19,7 +23,7 @@
     }
 
     @media only screen and (max-width: #{$mobile-width}) {
-      min-width: 95%; 
+      min-width: 95%;
     }
 
     .cm-completionInfo-right-narrow {
@@ -41,10 +45,12 @@
     strong {
       font-weight: 600;
     }
+
     p {
       line-height: 0.90em;
       margin: 0.5em 0;
     }
+
     code:not(.language-scala){
       padding: 0 0.4em;
       background-color: $code-background-color;


### PR DESCRIPTION
Codemirror wraps lint hovers when pointing at underline into additional div with broke the css.