### PR TITLE
Adjust scala steward updates

### DIFF
--- a/.scala-steward.conf
+++ b/.scala-steward.conf
@@ -3,5 +3,9 @@ pullRequests.frequency = "7 days"
 pullRequests.grouping = [
   { name = "patches", "title" = "Patch updates", "filter" = [{"version" = "patch"}] },
   { name = "minor_major", "title" = "Minor/major updates", "filter" = [{"version" = "minor"}, {"version" = "major"}] },
+  { name = "scalafmt", "title" = "Scalafmt update", "filter" = [{"artifact" = "scalafmt-core" }] }
 ]
 
+updates.ignore = [
+  { groupId = "org.scala-lang", artifactId = "scala3-library" }
+]


### PR DESCRIPTION
We don't want Scala version updates as in Scastie we are updating it manually.
Also Scalafmt changes do auto formating so they should be separated into separate PRs