### PR TITLE
Changed the proxy targets to 0.0.0.0

### DIFF
--- a/vite.config.js
+++ b/vite.config.js
@@ -69,10 +69,10 @@ if (!isDev()) {
 
 const proxy = {
   "/metals": {
-    target: "http://localhost:8000"
+    target: "http://0.0.0.0:8000"
   },
   "/": {
-    target: "http://localhost:9000",
+    target: "http://0.0.0.0:9000",
     bypass: function(req, res, proxyOptions) {
       // regex matching snippet ids
       const snippet = /(\/[A-Za-z0-9]{22}|\/[A-Za-z0-9]{22}\/([A-Za-z0-9])*[/(0-9)*])/;


### PR DESCRIPTION
Initially, with a clean build (using `sbt > startAll` and `yarn dev`), the proxy fails for API requests.

Tested on Linux 6.1.7-1-MANJARO.

Thanks to @rochala for the help!