### PR TITLE
fix: add scalafmt fileoverride for runtime

### DIFF
--- a/.scalafmt.conf
+++ b/.scalafmt.conf
@@ -8,6 +8,9 @@ fileOverride {
   "glob:**/metals-runner/src/**" {
     runner.dialect = scala3
   }
+  "glob:**/scalajvm-3/com.olegych.scastie.api.runtime/**" {
+      runner.dialect = scala3
+  }
 }
 
 docstrings = JavaDoc


### PR DESCRIPTION
Currently this is throwing in error in our Scala Steward run at
 https://github.com/scalacenter/steward/actions/runs/4169119430/jobs/7216704753#step:5:613 since
this is Scala 3 code that is currently being ran as with the scala2 dialect. This change just adds in an override for that dir to ensure it's treated as Scala 3