### PR TITLE
Don't use CrossVersion.for3Use2_13 in Scala.js

### DIFF
--- a/api/src/main/scala/com.olegych.scastie.api/ScalaTarget.scala
+++ b/api/src/main/scala/com.olegych.scastie.api/ScalaTarget.scala
@@ -208,8 +208,7 @@ object ScalaTarget {
                            else scalaJsVersion.split('.').head)
     )
 
-    def renderSbt(lib: ScalaDependency): String =
-      s"${renderSbtCross(lib)} cross CrossVersion.for3Use2_13"
+    def renderSbt(lib: ScalaDependency): String = renderSbtCross(lib)
 
     def sbtConfig: String = {
       s"""|$sbtConfigScalaVersion

--- a/project/SbtShared.scala
+++ b/project/SbtShared.scala
@@ -31,7 +31,7 @@ object SbtShared {
     val sbt        = latest212
     val jvm        = latest213
     val cross      = List(latest210, latest211, latest212, latest213, old3, js, sbt, jvm).distinct
-    val crossJS    = List(latest212, latest213, js).distinct
+    val crossJS    = List(latest212, latest213, stableLTS, js).distinct
   }
 
   object ScalaJSVersions {


### PR DESCRIPTION
Fix #1024 

This seems to be enough and, from my tests, both code compiled with Scala 3 and Scala 2.13 now works as expected.

I'm not sure if there's anything that I could have done to allow one to optionally use `CrossVersion.for3Use2_13`, but one can always just compile with 2.13 if that's the case.