### PR TITLE
Scala 2.13.14, Scala.js 1.16.0

### DIFF
--- a/api/src/main/scala/com.olegych.scastie.api/ScalaVersions.scala
+++ b/api/src/main/scala/com.olegych.scastie.api/ScalaVersions.scala
@@ -39,6 +39,7 @@ object ScalaVersions {
       case _ =>
         List(
           BuildInfo.latest213,
+          "2.13.13",
           "2.13.12",
           "2.13.11",
           "2.13.10",

--- a/project/SbtShared.scala
+++ b/project/SbtShared.scala
@@ -21,7 +21,7 @@ object SbtShared {
     val latest210  = "2.10.7"
     val latest211  = "2.11.12"
     val latest212  = "2.12.19"
-    val latest213  = "2.13.13"
+    val latest213  = "2.13.14"
     val old3       = "3.0.2"
     val stableLTS  = "3.3.3"
     val stableNext = "3.4.1"
@@ -35,7 +35,7 @@ object SbtShared {
   }
 
   object ScalaJSVersions {
-    val current = "1.13.2"
+    val current = "1.16.0"
   }
 
   val runtimeProjectName = "runtime-scala"


### PR DESCRIPTION
at https://contributors.scala-lang.org/t/scala-2-13-14-release-planning/6581/14 @sjrd said "I might not do earlier [Scala.js] releases" for 2.13.14, so I went ahead and bumped to 1.16.0 — let's see how CI likes it

review by @rochala ?