### PR TITLE
update Scala 3 default version to stableNext

### DIFF
--- a/api/src/main/scala/com.olegych.scastie.api/ScalaTarget.scala
+++ b/api/src/main/scala/com.olegych.scastie.api/ScalaTarget.scala
@@ -267,7 +267,7 @@ object ScalaTarget {
   }
 
   object Scala3 {
-    def default: ScalaTarget = Scala3(BuildInfo.stableLTS)
+    def default: ScalaTarget = Scala3(BuildInfo.stableNext)
 
     def defaultCode: String =
       """|// You can find more examples here:


### PR DESCRIPTION
# Fixes #1111 

This PR updates the default Scala 3 version to use `BuildInfo.stableNext`, ensuring that Scastie always uses the latest stable Scala 3 version by default.

## Changes

* **Updated `Scala3.default`** - Changed version to `BuildInfo.stableNext`