### PR TITLE
feat: add Toolkit toggle switch to ScaladexSearch

### DIFF
--- a/client/src/main/resources/sass/build-settings.scss
+++ b/client/src/main/resources/sass/build-settings.scss
@@ -170,6 +170,7 @@
         .search-input {
           height: 36px;
           width: 100%;
+          margin-top: 10px;
           .search-query {
             display: inline-block;
             width: 100%;
@@ -259,6 +260,72 @@
             display: inline-block
           }
         }
+      }
+
+      .toolbox-switch {
+        display: flex;
+        align-items: center;
+        margin: 8px 0;
+      }
+
+      .switch-container {
+        display: flex;
+        align-items: center;
+        cursor: pointer;
+      }
+
+      .switch-label {
+        margin-right: 12px;
+        font-size: 14px;
+      }
+
+      .switch {
+        position: relative;
+        display: inline-flex;
+        width: 50px;
+        height: 24px;
+      }
+
+      .switch-input {
+        opacity: 0;
+        width: 50px;
+        height: 24px;
+        position: absolute;
+        left: 0;
+        top: 0;
+        cursor: pointer;
+      }
+
+      .switch-slider {
+        position: absolute;
+        cursor: pointer;
+        top: 0;
+        left: 0;
+        right: 0;
+        bottom: 0;
+        background-color: #ccc;
+        border-radius: 24px;
+        transition: .3s;
+      }
+
+      .switch-slider:before {
+        position: absolute;
+        content: "";
+        height: 18px;
+        width: 18px;
+        left: 3px;
+        bottom: 3px;
+        background-color: white;
+        border-radius: 50%;
+        transition: .3s;
+      }
+
+      .switch-input:checked + .switch-slider {
+        background-color: #2196F3;
+      }
+
+      .switch-input:checked + .switch-slider:before {
+        transform: translateX(26px);
       }
     }
   }

--- a/client/src/main/resources/sass/build-settings.scss
+++ b/client/src/main/resources/sass/build-settings.scss
@@ -262,21 +262,15 @@
         }
       }
 
-      .toolbox-switch {
+      .toolkit-switch {
         display: flex;
         align-items: center;
         margin: 8px 0;
       }
 
-      .switch-container {
-        display: flex;
-        align-items: center;
-        cursor: pointer;
-      }
-
-      .switch-label {
-        margin-right: 12px;
-        font-size: 14px;
+      .switch-description {
+        margin-left: 16px;
+        font-size: 15px;
       }
 
       .switch {
@@ -303,7 +297,7 @@
         left: 0;
         right: 0;
         bottom: 0;
-        background-color: #ccc;
+        background-color: #b4b4b4;
         border-radius: 24px;
         transition: .3s;
       }
@@ -321,12 +315,19 @@
       }
 
       .switch-input:checked + .switch-slider {
-        background-color: #2196F3;
+        background-color: #2196f3;
       }
 
       .switch-input:checked + .switch-slider:before {
         transform: translateX(26px);
       }
+
+      .switch-slider.dark {
+        background-color: #595959;
+      }
+      .switch-input:checked + .switch-slider.dark {
+        background-color: #0b5089;
+}
     }
   }
 }

--- a/client/src/main/scala/com.olegych.scastie.client/components/BuildSettings.scala
+++ b/client/src/main/scala/com.olegych.scastie.client/components/BuildSettings.scala
@@ -63,7 +63,8 @@ object BuildSettings {
       updateDependencyVersion = props.updateDependencyVersion,
       addScalaDependency = props.addScalaDependency,
       librariesFrom = props.librariesFrom,
-      scalaTarget = props.scalaTarget
+      scalaTarget = props.scalaTarget,
+      isDarkTheme = props.isDarkTheme
     ).render
 
     div(cls := "build-settings-container")(

--- a/client/src/main/scala/com.olegych.scastie.client/components/ScaladexSearch.scala
+++ b/client/src/main/scala/com.olegych.scastie.client/components/ScaladexSearch.scala
@@ -23,7 +23,8 @@ final case class ScaladexSearch(
     updateDependencyVersion: (ScalaDependency, String) ~=> Callback,
     addScalaDependency: (ScalaDependency, Project) ~=> Callback,
     librariesFrom: Map[ScalaDependency, Project],
-    scalaTarget: ScalaTarget
+    scalaTarget: ScalaTarget,
+    isDarkTheme: Boolean
 ) {
   @inline def render: VdomElement = ScaladexSearch.component(this)
 }
@@ -447,6 +448,7 @@ object ScaladexSearch {
     val toolkitSwitchElem = toolkitSwitch(
       isEnabled = toolkitEnabled,
       onToggle = handleToolkitToggle,
+      isDarkTheme = props.isDarkTheme
     )
 
     div(cls := "search", cls := "library")(
@@ -487,13 +489,14 @@ object ScaladexSearch {
   private def toolkitSwitch(
     isEnabled: Boolean,
     onToggle: Boolean => Callback,
+    isDarkTheme: Boolean
   ): VdomElement = {
     val switchId = s"switch-$label".replace(" ", "-")
+    val sliderClass =
+    if (isDarkTheme) "switch-slider dark" else "switch-slider"
     div(
       cls := "toolkit-switch",
-      style := js.Dictionary("display" -> "flex", "alignItems" -> "center")
     )(
-      span(cls := "switch-label")(label),
       div(cls := "switch")(
         input(
           `type` := "checkbox",
@@ -505,13 +508,12 @@ object ScaladexSearch {
           }
         ),
         label(
-          cls := "switch-slider",
+          cls := sliderClass,
           htmlFor := switchId
         )
       ),
       span(
         cls := "switch-description",
-        style := js.Dictionary("marginLeft" -> "16px")
       )("Enable Toolkit")
     )
   }


### PR DESCRIPTION
# Fixes #938 
This pull request introduces a new "Toolkit" toggle feature in the Scaladex search component, along with corresponding UI and styling updates. The most important changes include adding a toggle switch for enabling/disabling the Toolkit dependency, implementing the necessary logic for handling the toggle state, and updating the styles to support the new UI elements.