### PR TITLE
feat: add Vim mode support with custom commands, toggle button, and help modal integration

### DIFF
--- a/client/src/main/resources/sass/codemirror.scss
+++ b/client/src/main/resources/sass/codemirror.scss
@@ -144,4 +144,31 @@
     -o-transition: opacity .6s;
     -ms-transition: opacity .6s;
   }
+
+  .cm-vim-panel {
+    background-color: #c4c6c7;
+    border: 1px solid #e2e8f0;
+    border-radius: 4px;
+    color: #2d3748;
+    font-family: $code-font-family;
+    padding: 8px 12px;
+    box-shadow: 0 4px 6px rgba(0, 0, 0, 0.1);
+  }
+
+  .cm-vim-panel input {
+    color: inherit;
+    font-family: inherit;
+  }
+
+  .dark .cm-vim-panel {
+    background-color: #1a202c !important;
+    border-color: #2d3748 !important;
+    color: #f7fafc !important;
+  }
+
+  .cm-editor:has(.cm-vim-panel) .cm-cursor,
+  .cm-editor:has(.cm-vim-panel) .cm-cursor-primary,
+  .cm-editor:has(.cm-vim-panel) .cm-vimCursorLayer {
+    display: none !important;
+  }
 }

--- a/client/src/main/resources/sass/editor-theme.scss
+++ b/client/src/main/resources/sass/editor-theme.scss
@@ -13,6 +13,13 @@
     }
   }
 
+  .vimModeIndicator {
+    color: $topbar-background;
+    &.enabled {
+      color: $worksheet-enabled;
+    }
+  }
+
   .editor-buttons {
     .btn {
       color: $editor-button-color;

--- a/client/src/main/resources/sass/editor.scss
+++ b/client/src/main/resources/sass/editor.scss
@@ -30,6 +30,19 @@
           opacity: 0.3;
         }
       }
+
+      .vimModeIndicator {
+        margin-right: 0px;
+        text-align: center;
+        width: 14px;
+        margin-left: 8px;
+        font-size: 14px;
+
+        &.enabled.alpha {
+          opacity: 0.3;
+        }
+      }
+
       .editor-buttons {
         white-space: nowrap;
 

--- a/client/src/main/scala/com.olegych.scastie.client/ScastieBackend.scala
+++ b/client/src/main/scala/com.olegych.scastie.client/ScastieBackend.scala
@@ -102,6 +102,9 @@ case class ScastieBackend(scastieId: UUID, serverUrl: Option[String], scope: Bac
   val toggleTheme: Reusable[Callback] =
     Reusable.always(scope.modState(_.toggleTheme))
 
+  val toggleVimMode: Reusable[Callback] =
+    Reusable.always(scope.modState(_.toggleVimMode))
+
   val setMetalsStatus: MetalsStatus ~=> Callback =
     Reusable.fn(status => scope.modState(_.setMetalsStatus(status)))
 

--- a/client/src/main/scala/com.olegych.scastie.client/ScastieState.scala
+++ b/client/src/main/scala/com.olegych.scastie.client/ScastieState.scala
@@ -66,7 +66,8 @@ object ScastieState {
       inputs = Inputs.default,
       outputs = Outputs.default,
       status = StatusState.empty,
-      isEmbedded = isEmbedded
+      isEmbedded = isEmbedded,
+      isVimMode = false,
     )
   }
 
@@ -111,6 +112,7 @@ case class ScastieState(
     metalsStatus: MetalsStatus = MetalsLoading,
     isEmbedded: Boolean = false,
     transient: Boolean = false,
+    isVimMode: Boolean = false,
 ) {
   def snippetId: Option[SnippetId] = snippetState.snippetId
   def loadSnippet: Boolean = snippetState.loadSnippet
@@ -137,6 +139,7 @@ case class ScastieState(
       status: StatusState = status,
       metalsStatus: MetalsStatus = metalsStatus,
       transient: Boolean = transient,
+      isVimMode: Boolean = isVimMode
   ): ScastieState = {
     val state0 =
       copy(
@@ -167,6 +170,7 @@ case class ScastieState(
         metalsStatus = metalsStatus,
         isEmbedded = isEmbedded,
         transient = transient,
+        isVimMode = isVimMode
       )
 
     if (!isEmbedded && !transient) {
@@ -202,6 +206,9 @@ case class ScastieState(
 
   def setTheme(dark: Boolean): ScastieState =
     copyAndSave(isDarkTheme = dark)
+
+  def toggleVimMode: ScastieState =
+    copyAndSave(isVimMode = !isVimMode)
 
   def setMetalsStatus(status: MetalsStatus): ScastieState =
     copyAndSave(metalsStatus = status)

--- a/client/src/main/scala/com.olegych.scastie.client/components/EditorTopBar.scala
+++ b/client/src/main/scala/com.olegych.scastie.client/components/EditorTopBar.scala
@@ -26,6 +26,8 @@ final case class EditorTopBar(clear: Reusable[Callback],
                               user: Option[User],
                               view: StateSnapshot[View],
                               isWorksheetMode: Boolean,
+                              isVimMode: Boolean,
+                              toggleVimMode: Reusable[Callback],
                               metalsStatus: MetalsStatus,
                               toggleMetalsStatus: Reusable[Callback],
                               scalaTarget: ScalaTarget) {
@@ -71,6 +73,12 @@ object EditorTopBar {
       props.isWorksheetMode,
       props.toggleWorksheetMode,
       props.view.value
+    ).render
+
+    val vimModeButton = VimModeButton(
+      isVimMode = props.isVimMode,
+      toggleVimMode = props.toggleVimMode,
+      view = props.view.value
     ).render
 
     val metalsButton = MetalsStatusIndicator(
@@ -121,6 +129,7 @@ object EditorTopBar {
         formatButton,
         clearButton,
         worksheetButton,
+        vimModeButton,
         downloadButton,
         embeddedModalButton,
         metalsButton,

--- a/client/src/main/scala/com.olegych.scastie.client/components/HelpModal.scala
+++ b/client/src/main/scala/com.olegych.scastie.client/components/HelpModal.scala
@@ -90,6 +90,19 @@ object HelpModal {
         p(
           "Your saved code fragments will appear here and you'll be able to delete or share them."
         ),
+        h2("Vim commands"),
+        p(
+          "If Vim mode is enabled in the editor, you can use the following commands in the Vim command bar (press ':' in normal mode):"
+        ),
+        ul(
+          li(code(":w"), " or ", code(":run"), " — Run and save your code (same as ", code(EditorKeymaps.saveOrUpdate.getName), ")"),
+          li(code(":f"), " or ", code(":format"), " — Format code (same as ", code(EditorKeymaps.format.getName), ")"),
+          li(code(":c"), " or ", code(":clear"), " — Clear messages (same as ", code(EditorKeymaps.clear.getName), ")"),
+          li(code(":h"), " or ", code(":help"), " — Show this help dialog")
+        ),
+        p(
+          "You can also use standard Vim navigation and editing commands in the editor."
+        ),
         h2("Feedback"),
         p( "You can join our ", gitter, " channel and send issues."),
         h2("BuildInfo"),

--- a/client/src/main/scala/com.olegych.scastie.client/components/MainPanel.scala
+++ b/client/src/main/scala/com.olegych.scastie.client/components/MainPanel.scala
@@ -63,6 +63,7 @@ object MainPanel {
         isPresentationMode = state.isPresentationMode,
         isWorksheetMode = state.inputs.isWorksheetMode,
         isEmbedded = props.isEmbedded,
+        isVimMode = state.isVimMode,
         showLineNumbers = state.showLineNumbers,
         value = state.inputs.code,
         attachedDoms = state.attachedDoms,
@@ -161,6 +162,8 @@ object MainPanel {
         user = state.user,
         view = backend.viewSnapshot(state.view),
         isWorksheetMode = state.inputs.isWorksheetMode,
+        isVimMode = state.isVimMode,
+        toggleVimMode = backend.toggleVimMode,
         metalsStatus = state.metalsStatus,
         toggleMetalsStatus = backend.toggleMetalsStatus,
         scalaTarget = state.inputs.target

--- a/client/src/main/scala/com.olegych.scastie.client/components/VimModeButton.scala
+++ b/client/src/main/scala/com.olegych.scastie.client/components/VimModeButton.scala
@@ -1,0 +1,54 @@
+package com.olegych.scastie
+package client
+package components
+
+import japgolly.scalajs.react._
+import vdom.all._
+
+final case class VimModeButton(
+    isVimMode: Boolean,
+    toggleVimMode: Reusable[Callback],
+    view: View
+) {
+  @inline def render: VdomElement = VimModeButton.component(this)
+}
+
+object VimModeButton {
+
+  implicit val reusability: Reusability[VimModeButton] =
+    Reusability.derive[VimModeButton]
+
+  private def render(props: VimModeButton): VdomElement = {
+    val isVimModeSelected =
+      if (props.isVimMode)
+        if (props.view != View.Editor)
+          TagMod(cls := "enabled alpha")
+        else
+          TagMod(cls := "enabled")
+      else
+        EmptyVdom
+
+    val isVimModeToggleLabel =
+      if (props.isVimMode) "OFF"
+      else "ON"
+
+    li(
+      title := s"Turn Vim mode $isVimModeToggleLabel (use Vim keybindings in the editor)",
+      isVimModeSelected,
+      role := "button",
+      cls := "btn editor",
+      onClick --> props.toggleVimMode
+    )(
+      i(cls := "fa fa-keyboard-o"),
+      span("Vim"),
+      i(cls := "vimModeIndicator", cls := "fa fa-circle", isVimModeSelected)
+    )
+  }
+
+  private val component =
+    ScalaComponent
+      .builder[VimModeButton]("VimModeButton")
+      .render_P(render)
+      .configure(Reusability.shouldComponentUpdate)
+      .build
+}

--- a/client/src/main/scala/com.olegych.scastie.client/components/editor/EditorKeymaps.scala
+++ b/client/src/main/scala/com.olegych.scastie.client/components/editor/EditorKeymaps.scala
@@ -7,6 +7,7 @@ import typings.codemirrorView.mod.{KeyBinding => JSKeyBinding}
 import typings.codemirrorCommands.mod._
 import typings.codemirrorAutocomplete.mod.acceptCompletion
 import typings.codemirrorState.mod._
+import typings.replitCodemirrorVim.mod.Vim_
 import com.olegych.scastie.client
 
 import scalajs.js
@@ -23,6 +24,49 @@ object EditorKeymaps {
     }
   }
 
+  def registerVimCommands(e: CodeEditor): Unit = {
+    Vim_.defineEx(
+      "w",
+      "",
+      (_, _) => e.saveOrUpdate.runNow()
+    )
+    Vim_.defineEx(
+      "run",
+      "",
+      (_, _) => e.saveOrUpdate.runNow()
+    )
+    Vim_.defineEx(
+      "f",
+      "",
+      (_, _) => e.formatCode.runNow()
+    )
+    Vim_.defineEx(
+      "format",
+      "",
+      (_, _) => e.formatCode.runNow()
+    )
+    Vim_.defineEx(
+      "c",
+      "",
+      (_, _) => e.clear.runNow()
+    )
+    Vim_.defineEx(
+      "clear",
+      "",
+      (_, _) => e.clear.runNow()
+    )
+    Vim_.defineEx(
+      "h",
+      "",
+      (_, _) => e.toggleHelp.runNow()
+    )
+    Vim_.defineEx(
+      "help",
+      "",
+      (_, _) => e.toggleHelp.runNow()
+    )
+  }
+
   val saveOrUpdate = new Key("Ctrl-Enter", "Meta-Enter")
   val saveOrUpdateAlt = new Key("Ctrl-s", "Meta-s")
   val openNewSnippetModal = new Key("Ctrl-m", "Meta-m")
@@ -33,21 +77,23 @@ object EditorKeymaps {
   val format = new Key("F6")
   val presentation = new Key("F8")
 
-  def keymapping(e: CodeEditor) =
-    typings.codemirrorView.mod.keymap.of(
-      js.Array(
-        KeyBinding.tabKeybind,
-        KeyBinding(_ => e.saveOrUpdate.runNow(), saveOrUpdate, true),
-        KeyBinding(_ => e.saveOrUpdate.runNow(), saveOrUpdateAlt, true),
-        KeyBinding(_ => e.openNewSnippetModal.runNow(), openNewSnippetModal, true),
-        KeyBinding(_ => e.clear.runNow(), clear, true),
-        KeyBinding(_ => e.clear.runNow(), clearAlt, true),
-        KeyBinding(_ => e.toggleHelp.runNow(), help, true),
-        KeyBinding(_ => e.toggleConsole.runNow(), console, true),
-        KeyBinding(_ => e.formatCode.runNow(), format, true),
-        KeyBinding(_ => presentationMode(e), presentation, true),
-      )
+  def keymapping(e: CodeEditor) = {
+    val base = js.Array(
+      KeyBinding.tabKeybind,
+      KeyBinding(_ => e.saveOrUpdate.runNow(), saveOrUpdate, true),
+      KeyBinding(_ => e.saveOrUpdate.runNow(), saveOrUpdateAlt, true),
+      KeyBinding(_ => e.openNewSnippetModal.runNow(), openNewSnippetModal, true),
+      KeyBinding(_ => e.clear.runNow(), clearAlt, true),
+      KeyBinding(_ => e.toggleHelp.runNow(), help, true),
+      KeyBinding(_ => e.toggleConsole.runNow(), console, true),
+      KeyBinding(_ => e.formatCode.runNow(), format, true),
+      KeyBinding(_ => presentationMode(e), presentation, true),
     )
+    if (!e.isVimMode) {
+      base.push(KeyBinding(_ => e.clear.runNow(), clear, true))
+    }
+    typings.codemirrorView.mod.keymap.of(base)
+  }
 }
 
 case class Key(default: String, linux: String, mac: String, win: String) {

--- a/package.json
+++ b/package.json
@@ -23,6 +23,7 @@
     "@lezer/common": "^1.0.3",
     "@lezer/highlight": "^1.1.6",
     "@replit/codemirror-indentation-markers": "^6.5.0",
+    "@replit/codemirror-vim": "^6.3.0",
     "@scala-js/vite-plugin-scalajs": "^1.0.0",
     "@sentry/browser": "^7.84.0",
     "@sentry/tracing": "^7.60.1",

--- a/yarn.lock
+++ b/yarn.lock
@@ -322,6 +322,11 @@
   resolved "https://registry.yarnpkg.com/@replit/codemirror-indentation-markers/-/codemirror-indentation-markers-6.5.0.tgz#e853e406cf05fea13449578c6c9c1383c6feb219"
   integrity sha512-5RgeuQ6erfROi1EVI2X7G4UR+KByjb07jhYMynvpvlrV22JlnARifmKMGEUKy0pKcxBNfwbFqoUlTYHPgyZNlg==
 
+"@replit/codemirror-vim@^6.3.0":
+  version "6.3.0"
+  resolved "https://registry.yarnpkg.com/@replit/codemirror-vim/-/codemirror-vim-6.3.0.tgz#1bcde09f25bcb1c4f96d2cd50ea07f9f71fc9ec4"
+  integrity sha512-aTx931ULAMuJx6xLf7KQDOL7CxD+Sa05FktTDrtLaSy53uj01ll3Zf17JdKsriER248oS55GBzg0CfCTjEneAQ==
+
 "@rollup/rollup-android-arm-eabi@4.9.1":
   version "4.9.1"
   resolved "https://registry.yarnpkg.com/@rollup/rollup-android-arm-eabi/-/rollup-android-arm-eabi-4.9.1.tgz#beaf518ee45a196448e294ad3f823d2d4576cf35"


### PR DESCRIPTION
# Add Vim Mode Support to Code Editor
This PR introduces Vim mode support to the Scastie code editor, allowing users to toggle Vim keybindings and use custom Vim commands directly in the editor. It also improves the user experience for Vim users by integrating a command bar and updating the help modal with Vim-specific instructions.

## Key changes include:
- Added support for Vim keybindings in the editor using `@replit/codemirror-vim`.
- Implemented custom commands (e.g., running code) accessible from Vim’s command bar (`:`).
- Added a button to the editor topbar to enable or disable Vim mode on demand.
- Extended the help modal with a section explaining available Vim commands and how to use Vim mode in Scastie.

## Screenshots
### Dark Theme

<img width="1041" height="611" alt="Zrzut ekranu 2025-08-27 o 15 07 06" src="https://github.com/user-attachments/assets/2cee699d-0219-45f2-95dd-20a112eb183a" />

### Light Theme

<img width="1041" height="609" alt="Zrzut ekranu 2025-08-27 o 15 08 17" src="https://github.com/user-attachments/assets/391e68ba-e836-4887-bc2c-e494ba8cb37e" />
