### PR TITLE
fix: improve tree-sitter build process with better npm install handling and logging

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -226,14 +226,28 @@ lazy val server = project
       val shell: Seq[String] = if (sys.props("os.name").contains("Windows")) Seq("cmd", "/c") else Seq("bash", "-c")
       val updateGitSubmodule: Seq[String] = shell :+ "git submodule update --init"
 
-      val installNpmDependencies: Seq[String] = shell :+ "cd tree-sitter-scala && npm install"
+      val installNpmDependencies: Seq[String] = shell :+ "npm install && cd tree-sitter-scala && npm install"
       val buildWasm: Seq[String] = shell :+ "cd tree-sitter-scala && npx tree-sitter build --wasm ."
       s.log.info("building tree-sitter-scala wasm...")
 
-      if ((updateGitSubmodule #&& installNpmDependencies #&& buildWasm !) == 0) {
-        s.log.success(s"$treeSitterOutputName build successfuly!")
+      val updateGitSubmoduleExit = Process(updateGitSubmodule, baseDirectory.value.getParentFile)
+        .!(ProcessLogger(line => s.log.info(s"[git submodule] $line"), err => s.log.error(s"[git submodule] $err")))
+      if (updateGitSubmoduleExit != 0) {
+        throw new IllegalStateException(s"Failed to update git submodule!")
+      }
+
+      val installNpmDependenciesExit = Process(installNpmDependencies, baseDirectory.value.getParentFile)
+        .!(ProcessLogger(line => s.log.info(s"[npm install] $line"), err => s.log.info(s"[npm install] $err")))
+      if (installNpmDependenciesExit != 0) {
+        throw new IllegalStateException(s"Failed to install npm dependencies!")
+      }
+
+      val buildWasmExitCode = Process(buildWasm, baseDirectory.value.getParentFile)
+        .!(ProcessLogger(line => s.log.info(s"[tree-sitter build] $line"), err => s.log.info(s"[tree-sitter build] $err")))
+      if (buildWasmExitCode != 0) {
+        throw new IllegalStateException("tree-sitter build failed!")
       } else {
-        throw new IllegalStateException(s"Failed to generate $treeSitterOutputName!")
+        s.log.success(s"$treeSitterOutputName build successfuly!")
       }
 
       sbt.IO.copyFile(treeSitterScalaHiglight, outputWasmDirectory / treeSitterScalaHiglightName)


### PR DESCRIPTION
# Fix flaky CI failures in buildTreesitterWasm task (follow-up)
## Context
This PR is a continuation of the previous attempt (#1136) to fix flaky CI failures in the `buildTreesitterWasm` SBT task. The earlier PR did not fully resolve the issue, as CI failures persisted due to missing files.
## Problem
The root cause of the problem was that npm install was not being run in the project root directory, so the `tree-sitter.wasm` file wasn't created. As a result, the build task failed when it tried to copy this file.
## Solution
This PR updates the build script to run npm install in both the root directory and the `tree-sitter-scala` directory, ensuring that all required dependencies (including web-tree-sitter) are installed and the necessary files are generated before proceeding with the build and copy steps.
## Additionally
- Each major step in the build process (`git submodule update`, `npm install`, and `tree-sitter build`) now logs both standard output and errors. This makes it much easier to debug issues in CI and to see exactly where a failure occurs.