### PR TITLE
fix: resolve validateDOMNesting warning for nested p elements in HelpModal

### DIFF
--- a/client/src/main/scala/org/scastie/client/components/HelpModal.scala
+++ b/client/src/main/scala/org/scastie/client/components/HelpModal.scala
@@ -29,9 +29,9 @@ object HelpModal {
           val element = elementBuilder(elementContent)
           val after = template.substring(m.end)
           
-          p(before, element, after)
+          span(before, element, after)
         case None =>
-          p(template)
+          span(template)
       }
     }
 


### PR DESCRIPTION
## Summary
This PR fixes validateDOMNesting warning.
## Key changes include
- Change renderWithElement function to use span instead of p elements to fix `validateDOMNesting: <p> cannot appear as descendant of <p>` warning.