### PR TITLE
fix: maintain toolkit switch state across Scala version changes

### DIFF
--- a/client/src/main/scala/org/scastie/client/components/ScaladexSearch.scala
+++ b/client/src/main/scala/org/scastie/client/components/ScaladexSearch.scala
@@ -423,8 +423,7 @@ object ScaladexSearch {
 
     val toolkitEnabled = props.libraries.exists { dep =>
       dep.groupId == "org.scala-lang" &&
-      dep.artifact == "toolkit" &&
-      dep.target == props.scalaTarget
+      dep.artifact == "toolkit"
     }
 
     def handleToolkitToggle(enabled: Boolean): Callback = {
@@ -440,11 +439,11 @@ object ScaladexSearch {
       if (enabled)
         addArtifact((toolkitProject, artifact, versionOpt), props.scalaTarget, state, props)
       else {
-        state.value.selecteds.find { selected =>
+        val toolkitSelecteds = state.value.selecteds.filter { selected =>
           selected.release.groupId == "org.scala-lang" &&
-          selected.release.artifact == "toolkit" &&
-          selected.release.target == props.scalaTarget
-        }.map(removeSelected).getOrElse(Callback.empty)
+          selected.release.artifact == "toolkit"
+        }
+        Callback.traverse(toolkitSelecteds)(removeSelected)
       }
     }
 


### PR DESCRIPTION
# Fixes #1145
This PR fixes an issue with the toolkit dependency switch, where changing the Scala version disabled the switch.
## Key changes include
- Update toolkit switch logic to check for any toolkit dependency regardless of Scala version/target. 
- Remove all toolkit versions when disabling switch.