### PR TITLE
fix: add sbtWithJRE back to Nix build inputs

### DIFF
--- a/default.nix
+++ b/default.nix
@@ -4,10 +4,16 @@ stdenv.mkDerivation {
   name = "scastie";
 
   buildInputs =
-    [
-      pkgs.nodejs
-      pkgs.yarn
-      pkgs.bash
-      pkgs.emscripten
-    ];
+    let
+      sbtWithJRE = pkgs.sbt.override {
+        jre = pkgs.jdk17_headless;
+      };
+    in
+      [
+        pkgs.nodejs
+        pkgs.yarn
+        pkgs.bash
+        pkgs.emscripten
+        sbtWithJRE
+      ];
 }


### PR DESCRIPTION
## Summary
This PR adds `sbtWithJRE` back to the `default.nix` configuration.