### PR TITLE
fix: use correct writeStatements for Scala.js and update deprecated dom.raw usage

### DIFF
--- a/README.MD
+++ b/README.MD
@@ -121,7 +121,7 @@ every time it's accessed.
 
 <pre class="scala-js">
 import org.scalajs.dom
-import org.scalajs.dom.raw.HTMLImageElement
+import org.scalajs.dom.HTMLImageElement
 
 val img = dom.document.createElement("img").asInstanceOf[HTMLImageElement]
 img.alt = "such dog" 

--- a/client/dev-static/scalajs.html
+++ b/client/dev-static/scalajs.html
@@ -5,7 +5,7 @@
 <pre class="scala-js">
 
 // fold
-import org.scalajs.dom.raw.HTMLImageElement
+import org.scalajs.dom.HTMLImageElement
 import org.scalajs.dom
 // end-fold
 
@@ -21,7 +21,7 @@ List(1, 2, 3).reverse
 
 <pre class="scala-js">
 // fold
-import org.scalajs.dom.raw.HTMLImageElement
+import org.scalajs.dom.HTMLImageElement
 import org.scalajs.dom
 // end-fold
 

--- a/client/src/main/resources/dev/embed.html
+++ b/client/src/main/resources/dev/embed.html
@@ -16,7 +16,7 @@ foo
 */
 
 // fold
-import org.scalajs.dom.raw.HTMLImageElement
+import org.scalajs.dom.HTMLImageElement
 import org.scalajs.dom
 // end-fold
 

--- a/client/src/main/scala/org/scastie/client/components/Console.scala
+++ b/client/src/main/scala/org/scastie/client/components/Console.scala
@@ -5,7 +5,7 @@ import org.scastie.client.ConsoleState
 import org.scastie.client.HTMLFormatter
 import org.scastie.client.View
 import japgolly.scalajs.react._
-import org.scalajs.dom.raw.HTMLDivElement
+import org.scalajs.dom.HTMLDivElement
 
 import vdom.all._
 

--- a/demo/dodge.scala
+++ b/demo/dodge.scala
@@ -1,4 +1,4 @@
-import org.scalajs.dom.raw.HTMLImageElement
+import org.scalajs.dom.HTMLImageElement
 import org.scalajs.dom
 
 val img = dom.document.createElement("img").asInstanceOf[HTMLImageElement]
@@ -6,7 +6,7 @@ img.alt = "such dog"
 img.src = "https://goo.gl/a3Xr41"
 img
 
-import org.scalajs.dom.raw.HTMLPreElement
+import org.scalajs.dom.HTMLPreElement
 import org.scalajs.dom
 
 val pre = dom.document.createElement("pre").asInstanceOf[HTMLPreElement]

--- a/instrumentation/src/main/scala/org/scastie/instrumentation/Instrument.scala
+++ b/instrumentation/src/main/scala/org/scastie/instrumentation/Instrument.scala
@@ -41,7 +41,7 @@ object Instrument {
   val entryPointName = "Main"
 
   private val elemArrayT =
-    "_root_.scala.scalajs.js.Array[_root_.org.scalajs.dom.raw.HTMLElement]"
+    "_root_.scala.scalajs.js.Array[_root_.org.scalajs.dom.HTMLElement]"
 
   private def extractExperimentalImports(code: String): (String, String) = {
     val experimentalRegex = """^\s*import\s+language\.experimental\.[^\n]+""".r
@@ -116,12 +116,7 @@ object Instrument {
         s"""|@$jsExportTopLevelT("ScastiePlaygroundMain") class ScastiePlaygroundMain {
             |  def suppressUnusedWarnsScastie = Html
             |  val playground = $runtimeErrorT.wrap($instrumentedObject)
-            |  @$jsExportT def result = playground match {
-            |    case Right(p) => 
-            |      p.main(Array())
-            |      $runtimeT.writeStatements(p.$$doc.getResults())
-            |    case Left(error) => $runtimeT.writeStatements(List())
-            |  }
+            |  @$jsExportT def result = $runtimeT.writeStatements(playground.map { playground => playground.main(Array()); playground.$$doc.getResults() })
             |  @$jsExportT def attachedElements: $elemArrayT =
             |    playground match {
             |      case Right(p) => p.attachedElements

--- a/instrumentation/src/test/resources/scalajs/instrumented.scala
+++ b/instrumentation/src/test/resources/scalajs/instrumented.scala
@@ -13,15 +13,10 @@ $t}
 @_root_.scala.scalajs.js.annotation.JSExportTopLevel("ScastiePlaygroundMain") class ScastiePlaygroundMain {
   def suppressUnusedWarnsScastie = Html
   val playground = _root_.org.scastie.runtime.api.RuntimeError.wrap(Playground)
-  @_root_.scala.scalajs.js.annotation.JSExport def result = playground match {
-    case Right(p) => 
-      p.main(Array())
-      _root_.org.scastie.runtime.Runtime.writeStatements(p.$doc.getResults())
-    case Left(error) => _root_.org.scastie.runtime.Runtime.writeStatements(List())
-  }
-  @_root_.scala.scalajs.js.annotation.JSExport def attachedElements: _root_.scala.scalajs.js.Array[_root_.org.scalajs.dom.raw.HTMLElement] =
+  @_root_.scala.scalajs.js.annotation.JSExport def result = _root_.org.scastie.runtime.Runtime.writeStatements(playground.map { playground => playground.main(Array()); playground.$doc.getResults() })
+  @_root_.scala.scalajs.js.annotation.JSExport def attachedElements: _root_.scala.scalajs.js.Array[_root_.org.scalajs.dom.HTMLElement] =
     playground match {
       case Right(p) => p.attachedElements
-      case Left(_) => _root_.scala.scalajs.js.Array[_root_.org.scalajs.dom.raw.HTMLElement]()
+      case Left(_) => _root_.scala.scalajs.js.Array[_root_.org.scalajs.dom.HTMLElement]()
     }
 }

--- a/runtime-scala/src/main/scala/scastie/runtime/SharedRuntime.scala
+++ b/runtime-scala/src/main/scala/scastie/runtime/SharedRuntime.scala
@@ -4,12 +4,8 @@ import org.scastie.runtime.api._
 
 protected[runtime] trait SharedRuntime {
 
-  def write(instrumentations: List[Instrumentation]): String = {
-    if (instrumentations.isEmpty) "" else instrumentations.map(_.asJsonString).mkString("[", ",", "]")
-  }
-
-  def writeStatements(statements: List[Statement]): String = {
-    val instrumentations = statements.flatMap { statement =>
+  def convertToInstrumentations(statements: List[Statement]): List[Instrumentation] = {
+    statements.flatMap { statement =>
       statement.binders.map { binder =>
         Instrumentation(
           position = binder.pos,
@@ -17,8 +13,14 @@ protected[runtime] trait SharedRuntime {
         )
       }
     }
+  }
 
-    write(instrumentations)
+  def write(instrumentations: List[Instrumentation]): String = {
+    if (instrumentations.isEmpty) "" else instrumentations.map(_.asJsonString).mkString("[", ",", "]")
+  }
+
+  def writeStatements(statements: List[Statement]): String = {
+    write(convertToInstrumentations(statements))
   }
 
   private val maxValueLength = 500

--- a/runtime-scala/src/main/scalajs/scastie/runtime/Runtime.scala
+++ b/runtime-scala/src/main/scalajs/scastie/runtime/Runtime.scala
@@ -8,9 +8,11 @@ import org.scastie.runtime.api._
 
 object Runtime extends SharedRuntime {
 
-  def write(in: Either[Option[RuntimeError], List[Instrumentation]]): String = {
+  def writeStatements(in: Either[Option[RuntimeError], List[Statement]]): String = {
     in match {
-      case Right(instrumentations) => ScalaJsResult(instrumentations, None).asJsonString
+      case Right(statements) =>
+        val instrumentations = convertToInstrumentations(statements)
+        ScalaJsResult(instrumentations, None).asJsonString
       case Left(error) => ScalaJsResult(Nil, error).asJsonString
     }
   }


### PR DESCRIPTION
# Fixes #1171
## Summary
This PR resolves a bug where the JVM version of `writeStatements` was incorrectly used when compiling Scala.js code, leading to errors. It also updates all deprecated references from `org.scalajs.dom.raw` to `org.scalajs.dom`.
## Key changes
- Ensured the correct version of writeStatements is used for Scala.js compilation.
- Replaced all deprecated `org.scalajs.dom.raw` usages with `org.scalajs.dom`.