### PR TITLE
fix: UI bug where divider line overlapped section header

### DIFF
--- a/client/src/main/scala/org/scastie/client/components/BuildSettings.scala
+++ b/client/src/main/scala/org/scastie/client/components/BuildSettings.scala
@@ -133,7 +133,7 @@ object BuildSettings {
 
   private def sbtBuildSettingsPanel(props: BuildSettings, sbtInputs: SbtInputs): TagMod = {
     div()(
-      h2(I18n.t("build.scala_version")),
+      h2(span(I18n.t("build.scala_version"))),
       VersionSelector(sbtInputs.target, props.setTarget).render,
       h2(span(I18n.t("build.libraries"))),
       scaladexSearch(props, sbtInputs),


### PR DESCRIPTION
## Summary
This PR fixes a UI issue where the horizontal divider line in the build settings panel overlapped the section header.

## Screenshots
### Before
<img width="440" height="112" alt="Zrzut ekranu 2025-11-3 o 18 24 03" src="https://github.com/user-attachments/assets/02ead214-0a59-421e-b315-316e9d3a95c6" />

### After
<img width="436" height="102" alt="Zrzut ekranu 2025-11-3 o 18 26 06" src="https://github.com/user-attachments/assets/d52c313c-727b-4c61-9c0e-583a9b5516f9" />
