### PR TITLE
fix(scala-cli): support quoted dependency directives and preserve libraries on target change

### DIFF
--- a/client/src/main/scala/org/scastie/client/scalacli/ScalaCliUtils.scala
+++ b/client/src/main/scala/org/scastie/client/scalacli/ScalaCliUtils.scala
@@ -19,7 +19,9 @@ object ScalaCliUtils {
       case ScalaVersionRegex(v) => ScalaVersionUtil.resolveVersion(v)
     }
     val dependencies = codeHeader.collect {
-      case DepRegex(_, dep) => dep
+      case DepRegex(_, dep) => 
+        val cleanDep = dep.trim.stripPrefix("\"").stripSuffix("\"")
+        cleanDep
     }.toSet
     val maybeToolkitVersion = codeHeader.collectFirst {
       case ToolkitRegex(v) => if (v == "latest") "latest.stable" else v


### PR DESCRIPTION
## Summary
This PR improves ScalaCLI dependency handling by supporting quoted dependency directives and ensuring libraries are preserved when switching between ScalaCLI and SBT targets.

## Key changes

- Allows the use of dependency directives with quotes, e.g.:
  - `//> using dep "org.typelevel::cats-core:2.13.0"`
- Strips surrounding quotes from dependency strings during parsing, so it is handled correctly.
- Fixes a bug where libraries added via quoted directives would disappear after changing the target (ScalaCLI ↔ SBT).