### PR TITLE
fix: display build errors to users during reload

### DIFF
--- a/sbt-runner/src/main/scala/org/scastie/sbt/OutputExtractor.scala
+++ b/sbt-runner/src/main/scala/org/scastie/sbt/OutputExtractor.scala
@@ -46,6 +46,8 @@ class OutputExtractor(getScalaJsContent: () => Option[String],
 
     val isScalaJs = inputs.target.targetType == ScalaTargetType.JS
 
+    val isSbtError = output.line.startsWith("[error]") && isReloading
+
     val userOutput =
       if (problems.toList.flatten.isEmpty
           && instrumentations.toList.flatten.isEmpty
@@ -54,6 +56,8 @@ class OutputExtractor(getScalaJsContent: () => Option[String],
           && !isHiddenSbtMessage
           && !isReloading
           && consoleOutput.isEmpty)
+        Some(output)
+      else if (isSbtError)
         Some(output)
       else None
 
@@ -64,9 +68,7 @@ class OutputExtractor(getScalaJsContent: () => Option[String],
         (None, None)
       }
 
-    val isSbtError = output.line.startsWith("[error]") && isReloading
-
-    val isReallyDone = (isDone && !isReloading) || isSbtError
+    val isReallyDone = isDone && !isReloading
 
     val sbtProcessOutput =
       consoleOutput match {

--- a/sbt-runner/src/main/scala/org/scastie/sbt/SbtProcess.scala
+++ b/sbt-runner/src/main/scala/org/scastie/sbt/SbtProcess.scala
@@ -236,10 +236,11 @@ class SbtProcess(runTimeout: FiniteDuration,
       sendProgress(sbtRun, progress)
 
       if (progress.isSbtError) {
+        sbtRun.timeoutEvent.foreach(_.cancel())
+        val finalProgress = progress.copy(isDone = true)
+        sendProgress(sbtRun, finalProgress)
         throw new Exception("sbt error: " + output.line)
-      }
-
-      if (isPrompt(output.line)) {
+      } else if (isPrompt(output.line)) {
         gotoRunning(sbtRun)
       } else {
         stay()


### PR DESCRIPTION
## Summary
This PR fixes an issue where sbt build configuration errors were not displayed to users in the console. Previously, when users provided invalid build settings (such as malformed `scalacOptions`), errors were only logged on the server side, leaving users without feedback on what went wrong.

## Key changes
- Modified `OutputExtractor.extractProgress()` to include `[error]` lines in `userOutput` when `isReloading=true`.
- Updated `SbtProcess` Reloading state to send final progress with `isDone=true` before throwing exception.

### Fixes #1205