### PR TITLE
feat: add /latest endpoint

### DIFF
--- a/balancer/src/main/scala/org/scastie/balancer/DispatchActor.scala
+++ b/balancer/src/main/scala/org/scastie/balancer/DispatchActor.scala
@@ -41,6 +41,7 @@ case class DownloadSnippet(snippetId: SnippetId)
 case class ForkSnippet(snippetId: SnippetId, inputs: InputsWithIpAndUser)
 
 case class FetchSnippet(snippetId: SnippetId)
+case class FetchLatestSnippet(snippetId: SnippetId)
 case class FetchOldSnippet(id: Int)
 case class FetchUserSnippets(user: User)
 
@@ -192,6 +193,10 @@ class DispatchActor(progressActor: ActorRef, statusActor: ActorRef)
     case FetchSnippet(snippetId) =>
       val sender = this.sender()
       logError(container.readSnippet(snippetId).map(sender ! _))
+
+    case FetchLatestSnippet(snippetId) =>
+      val sender = this.sender()
+      logError(container.readLatestSnippet(snippetId).map(sender ! _))
 
     case FetchOldSnippet(id) =>
       val sender = this.sender()

--- a/client/src/main/scala/org/scastie/client/RestApiClient.scala
+++ b/client/src/main/scala/org/scastie/client/RestApiClient.scala
@@ -98,6 +98,14 @@ class RestApiClient(serverUrl: Option[String]) extends RestApi {
   def fetch(snippetId: SnippetId): Future[Option[FetchResult]] =
     get[FetchResult]("/snippets/" + snippetId.url)
 
+  def fetchLatest(snippetId: SnippetId): Future[Option[FetchResult]] =
+    snippetId.user match {
+      case Some(SnippetUserPart(login, _)) =>
+        get[FetchResult](s"/snippets/$login/${snippetId.base64UUID}/latest")
+      case None =>
+        fetch(snippetId)
+    }
+
   def fetchOld(id: Int): Future[Option[FetchResult]] =
     get[FetchResult](s"/old-snippets/$id")
 

--- a/client/src/main/scala/org/scastie/client/RoutingADT.scala
+++ b/client/src/main/scala/org/scastie/client/RoutingADT.scala
@@ -43,6 +43,11 @@ case class UserResourceUpdated(
     update: Int
 ) extends ResourcePage
 
+case class UserResourceLatest(
+    login: String,
+    uuid: String
+) extends ResourcePage
+
 case class EmbeddedAnonymousResource(
     uuid: String
 ) extends ResourcePage

--- a/client/src/main/scala/org/scastie/client/ScastieBackend.scala
+++ b/client/src/main/scala/org/scastie/client/ScastieBackend.scala
@@ -423,6 +423,14 @@ case class ScastieBackend(scastieId: UUID, serverUrl: Option[String], scope: Bac
     )
   }
 
+  def loadLatestSnippet(snippetId: SnippetId): Callback = {
+    loadSnippetBase(
+      restApiClient.fetchLatest(snippetId),
+      afterLoading = _.setSnippetId(snippetId),
+      snippetId = Some(snippetId)
+    )
+  }
+
   private def loadSnippetBase(
       fetchSnippet: => Future[Option[FetchResult]],
       afterLoading: ScastieState => ScastieState = identity,

--- a/client/src/main/scala/org/scastie/client/components/Scastie.scala
+++ b/client/src/main/scala/org/scastie/client/components/Scastie.scala
@@ -118,7 +118,11 @@ object Scastie {
     val initialState = props.embedded match {
       case None => {
         props.snippetId match {
-          case Some(snippetId) => backend.loadSnippet(snippetId)
+          case Some(snippetId) =>
+            snippetId.user match {
+              case Some(SnippetUserPart(_, -1)) => backend.loadLatestSnippet(snippetId)
+              case _ => backend.loadSnippet(snippetId)
+            }
 
           case None => props.oldSnippetId match {
               case Some(id) => backend.loadOldSnippet(id)
@@ -136,7 +140,11 @@ object Scastie {
       }
       case Some(embededOptions) => {
         val setInputs = (embededOptions.snippetId, embededOptions.inputs) match {
-          case (Some(snippetId), _) => backend.loadSnippet(snippetId)
+          case (Some(snippetId), _) =>
+            snippetId.user match {
+              case Some(SnippetUserPart(_, -1)) => backend.loadLatestSnippet(snippetId)
+              case _ => backend.loadSnippet(snippetId)
+            }
 
           case (_, Some(inputs)) => backend.scope.modState(_.setInputs(inputs))
 

--- a/server/src/main/scala/org/scastie/server/RestApiServer.scala
+++ b/server/src/main/scala/org/scastie/server/RestApiServer.scala
@@ -81,6 +81,12 @@ class RestApiServer(
       .mapTo[Option[FetchResult]]
   }
 
+  def fetchLatest(snippetId: SnippetId): Future[Option[FetchResult]] = {
+    dispatchActor
+      .ask(FetchLatestSnippet(snippetId))
+      .mapTo[Option[FetchResult]]
+  }
+
   def fetchOld(id: Int): Future[Option[FetchResult]] = {
     dispatchActor
       .ask(FetchOldSnippet(id))

--- a/server/src/main/scala/org/scastie/server/routes/ApiRoutes.scala
+++ b/server/src/main/scala/org/scastie/server/routes/ApiRoutes.scala
@@ -62,6 +62,9 @@ class ApiRoutes(
           encodeResponseWith(Gzip)(
             get(
               concat(
+                snippetIdLatest("snippets")(
+                  sid => complete(server.fetchLatest(sid))
+                ),
                 snippetIdStart("snippets")(
                   sid => complete(server.fetch(sid))
                 ),

--- a/server/src/main/scala/org/scastie/server/routes/package.scala
+++ b/server/src/main/scala/org/scastie/server/routes/package.scala
@@ -24,6 +24,11 @@ package object routes {
       matcherStart / _ / matcherEnd
     )(f)
 
+  def snippetIdLatest(matcherStart: String)(f: SnippetId => Route): Route =
+    path(matcherStart / Segment / uuidMatcher / "latest" ~ Slash.?) { (user, uuid) =>
+      f(SnippetId(uuid, Some(SnippetUserPart(user, -1))))
+    }
+
   def snippetIdExtension(extension: String)(f: SnippetId => Route): Route =
     snippetIdBase(
       _ ~ extension,

--- a/storage/src/main/scala/org/scastie/storage/SnippetsContainer.scala
+++ b/storage/src/main/scala/org/scastie/storage/SnippetsContainer.scala
@@ -49,6 +49,7 @@ trait SnippetsContainer {
       snippetId: SnippetId
   ): Future[Option[FetchResultScalaJsSourceMap]]
   def readSnippet(snippetId: SnippetId): Future[Option[FetchResult]]
+  def readLatestSnippet(snippetId: SnippetId): Future[Option[FetchResult]]
   protected def insert(snippetId: SnippetId, inputs: BaseInputs): Future[Unit]
   protected def hideFromUserProfile(snippetId: SnippetId): Future[Unit]
 


### PR DESCRIPTION
## Summary
Adds a new `/latest` endpoint that fetches the most recent version of a snippet without requiring knowledge of the current update number.

### Fixes #1211