### PR TITLE
Add stable v1 compilation API endpoint (/api/v1/compile)

### DIFF
--- a/api/src/main/scala/org/scastie/api/StableCompilationApi.scala
+++ b/api/src/main/scala/org/scastie/api/StableCompilationApi.scala
@@ -1,0 +1,32 @@
+package org.scastie.api
+
+import io.circe.generic.semiauto._
+import io.circe.{Decoder, Encoder}
+
+/**
+  * Stable, minimal API models for triggering a compilation run from 3rd party websites.
+  *
+  * This API is intentionally small and versioned via the HTTP path (e.g. /api/v1/compile)
+  * so that Scastie's internal models (like BaseInputs) can evolve independently.
+  */
+
+final case class CompilationRequestV1(
+    code: String
+)
+
+object CompilationRequestV1 {
+  implicit val compilationRequestV1Encoder: Encoder[CompilationRequestV1] = deriveEncoder[CompilationRequestV1]
+  implicit val compilationRequestV1Decoder: Decoder[CompilationRequestV1] = deriveDecoder[CompilationRequestV1]
+}
+
+final case class CompilationResponseV1(
+    snippetId: SnippetId,
+    url: String
+)
+
+object CompilationResponseV1 {
+  implicit val compilationResponseV1Encoder: Encoder[CompilationResponseV1] = deriveEncoder[CompilationResponseV1]
+  implicit val compilationResponseV1Decoder: Decoder[CompilationResponseV1] = deriveDecoder[CompilationResponseV1]
+}
+
+

--- a/server/src/main/scala/org/scastie/server/routes/ApiRoutes.scala
+++ b/server/src/main/scala/org/scastie/server/routes/ApiRoutes.scala
@@ -31,6 +31,17 @@ class ApiRoutes(
         concat(
           post(
             concat(
+              pathPrefix("v1") {
+                path("compile") {
+                  entity(as[CompilationRequestV1]) { request =>
+                    complete(
+                      server
+                        .run(SbtInputs.default.copy(code = request.code))
+                        .map(snippetId => CompilationResponseV1(snippetId, snippetId.url))
+                    )
+                  }
+                }
+              },
               path("run")(
                 entity(as[BaseInputs])(inputs => complete(server.run(inputs)))
               ),


### PR DESCRIPTION
This PR implements a new stable, versioned compilation API as requested in
https://github.com/scalacenter/scastie/issues/805.

### What this adds
- A new public, stable request/response model:
  - `CompilationRequestV1` – minimal payload containing the Scala code.
  - `CompilationResponseV1` – returns `SnippetId` and a public snippet URL.
- Circe encoders/decoders so the models are stable and serialization-safe.
- A new HTTP endpoint:

      POST /api/v1/compile

  This endpoint:
  - Accepts JSON: `{ "code": "<scala code>" }`
  - Maps the code into `SbtInputs.default.copy(code = request.code)`
  - Reuses the existing compilation pipeline (`server.run(...)`)
  - Returns a stable JSON result:

        {
          "snippetId": { ... },
          "url": "https://scastie.scala-lang.org/<id>"
        }

### Why this is useful
- Provides a stable, versioned API surface for external tools such as
  Scala documentation, the Tour, scala-exercises, tutorials, and educational tooling.
- Decouples public API types from internal models (`BaseInputs`, etc.).
- Offers a forward-compatible foundation for future API versions.
- Keeps the existing `/api/run` endpoint unchanged.

### Notes
- Endpoint uses the same config/CORS setup as the rest of `/api`.
- Implementation is minimal and directly composes with the current compilation infrastructure.
@