### PR TITLE
fix: prevent duplicate snippet URLs when saving without changes

### DIFF
--- a/client/src/main/scala/org/scastie/client/ScastieBackend.scala
+++ b/client/src/main/scala/org/scastie/client/ScastieBackend.scala
@@ -374,9 +374,9 @@ case class ScastieBackend(scastieId: UUID, serverUrl: Option[String], scope: Bac
               state.snippetId match {
                 case Some(snippetId) =>
                   if (snippetId.isOwnedBy(state.user)) {
-                    update0(snippetId)
+                    if (state.inputsHasChanged) update0(snippetId) else run
                   } else {
-                    fork0(snippetId)
+                    if (state.inputsHasChanged) fork0(snippetId) else run
                   }
                 case None => save0
               }


### PR DESCRIPTION
## Summary
- Fixes issue where pressing save (Cmd+S/Ctrl+S) without making any code changes would create a new snippet URL
- Now checks `inputsHasChanged` before calling `update0` or `fork0`
- If no changes, just re-runs the existing code via `run` without creating a new snippet

### Fixes #1241