### PR TITLE
feat: use willNeedReload to consider full mailbox

### DIFF
--- a/balancer/src/main/scala/org/scastie/balancer/SbtLoadBalancer.scala
+++ b/balancer/src/main/scala/org/scastie/balancer/SbtLoadBalancer.scala
@@ -41,7 +41,7 @@ case class SbtLoadBalancer[R, S <: ServerState](servers: Vector[SbtServer[R, S]]
       val selectedServer = availableServers.maxBy { s =>
         (
           s.mailbox.length < 3, //allow reload if server gets busy
-          !s.currentConfig.needsReload(task.config), //pick those without need for reload
+          !s.configAfterMailbox.needsReload(task.config), //pick those without need for reload
           -s.mailbox.length, //then those least busy
           lastTenMinutes(s.mailbox ++ s.history.data).exists(!_.config.needsReload(task.config)), //then those which use(d) this config
           lastWithIp(s.mailbox).orElse(lastWithIp(s.history.data)).map(_.ts.toEpochMilli), //then one most recently used by this ip, if any

--- a/balancer/src/main/scala/org/scastie/balancer/ScalaCliLoadBalancer.scala
+++ b/balancer/src/main/scala/org/scastie/balancer/ScalaCliLoadBalancer.scala
@@ -32,7 +32,7 @@ case class ScalaCliLoadBalancer[R, S <: ServerState](servers: Vector[ScalaCliSer
       val selectedServer = availableServers.maxBy { s =>
         (
           s.mailbox.length < 3, // allow reload if server gets busy
-          !s.currentConfig.needsReload(task.config), // pick those without need for reload
+          !s.configAfterMailbox.needsReload(task.config), // pick those without need for reload
           -s.mailbox.length // then those least busy
         )
       }

--- a/balancer/src/main/scala/org/scastie/balancer/Server.scala
+++ b/balancer/src/main/scala/org/scastie/balancer/Server.scala
@@ -27,6 +27,7 @@ case class Server[R, S, C <: BaseInputs](
 
   def currentTaskId: Option[TaskId] = mailbox.headOption.map(_.taskId)
   def currentConfig: C = mailbox.headOption.map(_.config).getOrElse(lastConfig)
+  def configAfterMailbox: C = mailbox.lastOption.map(_.config).getOrElse(lastConfig)
 
   def done(taskId: TaskId): Server[R, S, C] = {
     val (newMailbox, done) = mailbox.partition(_.taskId != taskId)


### PR DESCRIPTION
Instead of looking at the current state of a runner's config, the balancer will look at the state of the runner after all queued tasks are done.

Based on https://github.com/scalacenter/scastie/pull/1258