### PR TITLE
chore: metals 1.6.7 bump

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -129,8 +129,8 @@ lazy val metalsRunner = project
     maintainer   := "scalacenter",
     scalaVersion := ScalaVersions.stableLTS,
     libraryDependencies ++= Seq(
-      "org.scalameta"        % "metals"              % "1.6.5" cross (CrossVersion.for3Use2_13),
-      "org.eclipse.lsp4j"    % "org.eclipse.lsp4j"   % "0.21.1",
+      "org.scalameta"        % "metals"              % "1.6.7" cross (CrossVersion.for3Use2_13),
+      "org.eclipse.lsp4j"    % "org.eclipse.lsp4j"   % "1.0.0",
       "org.http4s"          %% "http4s-ember-server" % "0.23.24",
       "org.http4s"          %% "http4s-ember-client" % "0.23.24",
       "org.http4s"          %% "http4s-dsl"          % "0.23.24",

--- a/metals-runner/src/main/scala/org/scastie/metals/DTOExtensions.scala
+++ b/metals-runner/src/main/scala/org/scastie/metals/DTOExtensions.scala
@@ -51,7 +51,7 @@ object DTOExtensions {
         Option(diagnostic.getRange().getEnd().getLine() - worksheetLineOffset + 1),
         Option(diagnostic.getRange().getStart().getCharacter() - worksheetOffset + 1),
         Option(diagnostic.getRange().getEnd().getCharacter() - worksheetOffset + 1),
-        diagnostic.getMessage(),
+        diagnostic.getMessage().map(identity, _.getValue),
         actions
       )
 


### PR DESCRIPTION
Metals 1.6.5 was incompatible with Scala 3.8.4 and threw an error.
```
==> X org.scastie.metals.MetalsServerTest.Completions item info with dependencies 
0.893s java.lang.NoSuchMethodError: 'scala.meta.pc.SourcePathMode
scala.meta.pc.PresentationCompilerConfig.sourcePathMode()'
```